### PR TITLE
prevent date overflowing 2 lines

### DIFF
--- a/src/components/weather/common/CollapsibleListHeader.tsx
+++ b/src/components/weather/common/CollapsibleListHeader.tsx
@@ -44,7 +44,10 @@ const CollapsibleListHeader: React.FC<CollapsiblePanelHeaderProps> = ({
           },
         ]}>
         <View style={[styles.rowColumn, styles.alignStart]}>
-          <Text style={[styles.title, { color: colors.primaryText }]}>
+          <Text
+            style={[styles.title, { color: colors.primaryText }]}
+            numberOfLines={2}
+            ellipsizeMode="clip">
             {title}
           </Text>
         </View>


### PR DESCRIPTION
Fixes forecast date overflowing to 3 lines when long enough, e.g.:
```
Pe
24.12
.
```