### PR TITLE
remove tab bar negative bottom margin on ios

### DIFF
--- a/src/navigators/TabNavigator.tsx
+++ b/src/navigators/TabNavigator.tsx
@@ -457,17 +457,6 @@ const styles = StyleSheet.create({
   },
   tabItem: {
     borderTopWidth: 3,
-    ...Platform.select({
-      android: {
-        marginBottom: 0,
-      },
-      ios: {
-        marginBottom: -10,
-      },
-      default: {
-        marginBottom: 0,
-      },
-    }),
   },
   header: {
     shadowOffset: {


### PR DESCRIPTION
Negative bottom margin broke tab bar on some ios devices. Remove to fix.