### PR TITLE
Chore/fixes

### DIFF
--- a/src/components/weather/charts/Chart.tsx
+++ b/src/components/weather/charts/Chart.tsx
@@ -133,7 +133,9 @@ const Chart: React.FC<ChartProps> = ({
     const { contentOffset } = nativeEvent;
     setScrollIndex(contentOffset.x);
     if (currentDayOffset && setActiveDayIndex) {
-      const dayIndex = calculateDayIndex(contentOffset.x);
+      let dayIndex = calculateDayIndex(contentOffset.x);
+      dayIndex = dayIndex >= 0 ? dayIndex : 0;
+
       if (dayIndex !== activeDayIndex) {
         setActiveDayIndex(dayIndex);
       }

--- a/src/components/weather/charts/Chart.tsx
+++ b/src/components/weather/charts/Chart.tsx
@@ -55,7 +55,7 @@ const Chart: React.FC<ChartProps> = ({
     Config.get('weather').observation;
 
   const tickInterval = observation && timePeriod && timePeriod > 24 ? 1 : 3;
-  const stepLength = tickInterval === 1 ? 26 : 13;
+  const stepLength = tickInterval === 1 ? 20 : 8;
 
   const chartWidth =
     observation && timePeriod

--- a/src/components/weather/charts/WindChart.tsx
+++ b/src/components/weather/charts/WindChart.tsx
@@ -32,27 +32,40 @@ const WindChart: React.FC<ChartDataProps> = ({
         }))
       : false;
 
+  const labelData = (windDirection || []).sort((a, b) => a.x - b.x);
+  const labelSize = 20;
+  const labelInterval =
+    width /
+      ((labelData[labelData.length - 1]?.x - labelData[0]?.x) /
+        (60 * 60 * 1000)) >
+    labelSize
+      ? 1
+      : 3;
+
   const WindLabel = (datum: any) => {
     const { index: dIndex, x: dX } = datum;
-    if (!windDirection || windDirection.length === 0) {
+    if (labelData.length === 0) {
       return null;
     }
 
     const index = Number(dIndex);
-
-    const { x, y } = windDirection[index];
+    const { x, y } = labelData[index];
     const time = moment(x);
 
-    if (y === null || time.minutes() !== 0) {
+    if (
+      y === null ||
+      time.minutes() !== 0 ||
+      time.hours() % labelInterval !== 0
+    ) {
       return null;
     }
 
     return (
-      <View style={[styles.arrowStyle, { left: dX - 10 }]}>
+      <View style={[styles.arrowStyle, { left: dX - labelSize / 2 }]}>
         <Icon
           name="wind-arrow"
-          width={20}
-          height={20}
+          width={labelSize}
+          height={labelSize}
           style={{
             color: colors.primaryText,
             transform: [
@@ -73,6 +86,7 @@ const WindChart: React.FC<ChartDataProps> = ({
           data={combinedData}
           domain={domain}
           style={{ data: { fill: '#d8d8d8' } }}
+          interpolation="natural"
         />
       )}
 

--- a/src/components/weather/forecast/ForecastByHourList.tsx
+++ b/src/components/weather/forecast/ForecastByHourList.tsx
@@ -307,7 +307,9 @@ const ForecastByHourList: React.FC<ForecastByHourListProps> = ({
     nativeEvent,
   }: NativeSyntheticEvent<NativeScrollEvent>) => {
     const { contentOffset } = nativeEvent;
-    const dayIndex = Math.ceil((contentOffset.x / 52 - currentDayOffset) / 24);
+    let dayIndex = Math.ceil((contentOffset.x / 52 - currentDayOffset) / 24);
+    dayIndex = dayIndex >= 0 ? dayIndex : 0;
+
     if (dayIndex !== currentIndex) setCurrentIndex(dayIndex);
     if (dayIndex !== activeDayIndex) {
       setActiveDayIndex(dayIndex);

--- a/src/navigators/TabNavigator.tsx
+++ b/src/navigators/TabNavigator.tsx
@@ -315,6 +315,11 @@ const Navigator: React.FC<Props> = ({
         component={TermsAndConditionsScreen}
         options={{
           ...CommonHeaderOptions,
+          headerTintColor: PRIMARY_BLUE,
+          headerStyle: {
+            ...styles.header,
+            shadowColor: SHADOW_LIGHT,
+          },
           headerTitle: t('setUp:termsAndConditions'),
         }}
       />

--- a/src/network/WeatherApi.ts
+++ b/src/network/WeatherApi.ts
@@ -18,7 +18,7 @@ export const getForecast = async (
 
   const params = {
     ...location,
-    starttime: 0,
+    starttime: Math.floor(Date.now() / 60 / 1000) * 60,
     endtime: timePeriod,
     format: 'json',
     attributes: 'geoid',

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -177,6 +177,7 @@ const MapScreen: React.FC<MapScreenProps> = ({
         customMapStyle={darkGoogleMapsStyle}
         initialRegion={initialRegion}
         rotateEnabled={false}
+        toolbarEnabled={false}
         onRegionChangeComplete={onRegionChangeComplete}>
         {overlay && overlay.type === 'WMS' && <WMSOverlay overlay={overlay} />}
         {overlay && overlay.type === 'Timeseries' && (

--- a/src/store/forecast/reducer.ts
+++ b/src/store/forecast/reducer.ts
@@ -22,17 +22,27 @@ const INITIAL_STATE: ForecastState = {
   fetchTimestamp: Date.now(),
 };
 
-const formatData = (data: WeatherData[]): WeatherData => {
+const formatData = (dataSets: WeatherData[]): WeatherData => {
   const weatherData: WeatherData = {};
-  data.forEach((foo) => {
-    Object.entries(foo).forEach(([id, steps]) => {
-      Object.assign(weatherData, { [id]: weatherData[id] || [] });
-      weatherData[id] = steps.map((step) => ({
-        ...(weatherData[id].find(
-          ({ epochtime }) => epochtime === step.epochtime
-        ) || {}),
-        ...step,
-      }));
+  dataSets.forEach((dataSet) => {
+    Object.entries(dataSet).forEach(([id, steps]) => {
+      if (!weatherData[id]) {
+        Object.assign(weatherData, { [id]: steps });
+      } else {
+        steps.forEach((step) => {
+          const timeIndex = weatherData[id].findIndex(
+            ({ epochtime }) => epochtime === step.epochtime
+          );
+          if (timeIndex >= 0) {
+            Object.assign(weatherData[id][timeIndex], {
+              ...weatherData[id][timeIndex],
+              ...step,
+            });
+          } else {
+            weatherData[id].push(step);
+          }
+        });
+      }
     });
   });
   return weatherData;
@@ -62,7 +72,6 @@ export default (
           { ...state.data, ...formatData(action.data) },
           action.favorites
         ),
-        // data: formatData([state.data || {}, ...action.data], action.favorites),
         fetchTimestamp: action.timestamp,
         loading: false,
         error: false,

--- a/src/store/observation/selector.ts
+++ b/src/store/observation/selector.ts
@@ -37,12 +37,12 @@ export const selectDataId = createSelector(
 
 export const selectStationId = createSelector(
   [selectDataId, selectStationIdList],
-  (id, stations) => (stations ? stations[id] : 0)
+  (id, stations) => (stations?.[id] ? stations[id] : 0)
 );
 
 export const selectData = createSelector(
   [selectDataSets, selectStationId],
-  (data, id) => (data ? data[id] : [])
+  (data, id) => (data?.[id] ? data[id] : [])
 );
 
 export const selectDisplayFormat = createSelector(

--- a/src/store/warnings/actions.ts
+++ b/src/store/warnings/actions.ts
@@ -2,7 +2,9 @@ import { Dispatch } from 'react';
 import getWarnings from '@network/WarningsApi';
 import { Location } from '@store/location/types';
 import {
+  Error,
   FETCH_WARNINGS,
+  FETCH_WARNINGS_ERROR,
   FETCH_WARNINGS_SUCCESS,
   WarningsActionTypes,
 } from './types';
@@ -11,13 +13,18 @@ const fetchWarnings =
   (location: Location) => (dispatch: Dispatch<WarningsActionTypes>) => {
     dispatch({ type: FETCH_WARNINGS });
 
-    getWarnings(location).then((data) => {
-      dispatch({
-        type: FETCH_WARNINGS_SUCCESS,
-        data,
-        id: location.id,
+    getWarnings(location)
+      .then((data) => {
+        dispatch({
+          type: FETCH_WARNINGS_SUCCESS,
+          data,
+          id: location.id,
+          timestamp: Date.now(),
+        });
+      })
+      .catch((error: Error) => {
+        dispatch({ type: FETCH_WARNINGS_ERROR, error, timestamp: Date.now() });
       });
-    });
   };
 
 export default fetchWarnings;

--- a/src/store/warnings/reducer.ts
+++ b/src/store/warnings/reducer.ts
@@ -11,6 +11,7 @@ const INITIAL_STATE: WarningsState = {
   data: {},
   loading: false,
   error: false,
+  fetchTimestamp: Date.now(),
 };
 
 export default (
@@ -33,6 +34,7 @@ export default (
           ...state.data,
           [action.id]: action.data,
         },
+        fetchTimestamp: action.timestamp,
       };
     }
 
@@ -41,6 +43,7 @@ export default (
         ...state,
         loading: false,
         error: action.error,
+        fetchTimestamp: action.timestamp,
       };
     }
 

--- a/src/store/warnings/selectors.ts
+++ b/src/store/warnings/selectors.ts
@@ -32,15 +32,20 @@ export const selectUpdated = createSelector(
   (items, geoid) => items?.[geoid]?.updated || null
 );
 
+const selectFetchTimestamp = createSelector(
+  selectWarningsDomain,
+  (warnings) => warnings.fetchTimestamp
+);
+
 export const selectDailyWarningData = createSelector(
-  [selectWarnings],
-  (warnings) => {
+  [selectWarnings, selectFetchTimestamp],
+  (warnings, fetchTime) => {
     const dayCount = 5;
     const severityList = ['', 'Moderate', 'Severe', 'Extreme'];
 
     const days = Array.from({ length: dayCount }, (_, i) => {
-      const dayStart = moment().startOf('day').add(i, 'days');
-      const dayEnd = moment().endOf('day').add(i, 'days');
+      const dayStart = moment(fetchTime).startOf('day').add(i, 'days');
+      const dayEnd = moment(fetchTime).endOf('day').add(i, 'days');
 
       const dailyWarnings = warnings.filter(
         ({ duration: { startTime, endTime } }) =>

--- a/src/store/warnings/types.ts
+++ b/src/store/warnings/types.ts
@@ -10,11 +10,13 @@ interface FetchWarningsSuccess {
   type: typeof FETCH_WARNINGS_SUCCESS;
   data: WarningsData;
   id: number;
+  timestamp: number;
 }
 
 interface FetchWarningsError {
   type: typeof FETCH_WARNINGS_ERROR;
   error: Error;
+  timestamp: number;
 }
 
 export type WarningsActionTypes =
@@ -67,4 +69,5 @@ export interface WarningsState {
   data: LocationWarnings;
   loading: boolean;
   error: boolean | Error | string;
+  fetchTimestamp: number;
 }


### PR DESCRIPTION
* Fix selecting negative dayIndex causing app to crash ( closes #164 )
* Observations selector type fixes ( closes #165 )
* Fix forecast data sets merge losing timesteps
* Fix SetupStack darkmode headers
* Disalbe toolbar in android map ( closes #167 )
* Use fetchTimestamp to make warning days to keep them up to date ( closes #171 )
* Fix forecasts mismatched first steps ( closes #168 ).
* Fix chart WindLabels & try sorter charts to help with vertical scrolling performance