### PR TITLE
implement forecast or observation only wms layer

### DIFF
--- a/src/components/map/layers/WMSOverlay.tsx
+++ b/src/components/map/layers/WMSOverlay.tsx
@@ -78,7 +78,7 @@ const WMSOverlay: React.FC<WMSOverlayProps> = ({
 
   const formatUrlWithStyles = (timestamp: string): string | false => {
     const isForecast = borderTimeComparer(timestamp);
-    const { url, styles } = isForecast ? forecast : observation;
+    const { url, styles } = (isForecast ? forecast : observation) || {};
     if (!url) {
       return false;
     }

--- a/src/utils/map.ts
+++ b/src/utils/map.ts
@@ -197,6 +197,7 @@ const getWMSLayerUrlsAndBounds = async (
         params: {
           service: 'WMS',
           request: 'GetCapabilities',
+          layout: 'flat',
           who: packageJSON.name,
           ...(src.includes('smartmet')
             ? {


### PR DESCRIPTION
Adds support for WMS layers with only forecast or observation defined.

Partial mock config:
```
map: {
    updateInterval: 5,
    sources: {
      source: http://source.example,
    },
    layers: [
      {
        id: 1,
        type: 'WMS',
        name: { en: 'test', fi: 'test', sv: 'test' },
        sources: [
          {
            source: 'source',
            layer: 'some:wms:layer',
            type: 'forecast',
          },
        ],
        times: {
          timeStep: 180,
          forecast: 4,
        },
      },
    ],
},
```

Closes #335 