### PR TITLE
Fix interaction problems between day selector and chart

### DIFF
--- a/src/components/weather/charts/Chart.tsx
+++ b/src/components/weather/charts/Chart.tsx
@@ -72,11 +72,13 @@ const Chart: React.FC<ChartProps> = ({
       const dayIndex = calculateDayIndex(scrollIndex);
       if (activeDayIndex === 0 && dayIndex !== activeDayIndex) {
         scrollRef.current.scrollTo({ x: 0, animated: true });
+        setScrollIndex(0);
       }
       if (activeDayIndex > 0 && dayIndex !== activeDayIndex) {
         const off = currentDayOffset * stepLength;
         const offsetX = off + (activeDayIndex - 1) * 24 * stepLength;
         scrollRef.current.scrollTo({ x: offsetX, animated: true });
+        setScrollIndex(offsetX);
       }
     }
   }, [


### PR DESCRIPTION
The issue in #317 is that the dayIndex is not kept up-to-date, leading conditions in if-statements to evaluate to incorrect values and thus skipping scrolling when it should not be skipped.

This PR keeps the scrollIndex up-to-date, which in turn keeps the dayIndex up-to-date.