### PR TITLE
Fix displayed precision of temperature observations

### DIFF
--- a/i18n/fi.json
+++ b/i18n/fi.json
@@ -404,7 +404,7 @@
     "59": "Runsasta lumisadetta",
     "61": "Yksittäisiä raekuuroja",
     "64": "Paikoin raekuuroja",
-    "67": "Reakuuroja",
+    "67": "Raekuuroja",
     "71": "Yksittäisiä ukkoskuuroja",
     "74": "Paikoin ukkoskuuroja",
     "77": "Ukkoskuuroja",

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -133,11 +133,12 @@ const minusParams = ['temperature', 'dewPoint'];
 export const convertValueToUnitPrecision = (
   unit: string,
   unitAbb: string,
-  val: number | undefined | null
+  val: number | undefined | null,
+  decimals?: number
 ) => {
   const result =
     val || val === 0
-      ? toPrecision(unit, unitAbb, converter(unitAbb, val))
+      ? toPrecision(unit, unitAbb, converter(unitAbb, val), decimals)
       : null;
   return result;
 };
@@ -146,7 +147,7 @@ export const getObservationCellValue = (
   item: ObsTimeStepData,
   param: keyof ObsTimeStepData,
   unit: string,
-  decimal?: number,
+  decimals?: number,
   divider?: number,
   showUnit?: boolean
 ): string => {
@@ -165,14 +166,15 @@ export const getObservationCellValue = (
       ? convertValueToUnitPrecision(
           unitParameterObject.parameterName,
           unitAbb,
-          Number(dividedValue)
+          Number(dividedValue),
+          decimals
         )
       : dividedValue;
     if (!value) return '-';
 
     return `${(unitParameterObject
       ? value
-      : Number(value).toFixed(decimal || 0)
+      : Number(value).toFixed(decimals || 0)
     )
       .toString()
       .replace('.', ',')} ${showUnit ? unit : ''}`.trim();

--- a/src/utils/units.ts
+++ b/src/utils/units.ts
@@ -137,14 +137,15 @@ export const getDefaultUnits = (): UnitMap | undefined => {
 export const toPrecision = (
   unit: string,
   unitAbb: string,
-  value: number
+  value: number,
+  decimals?: number
 ): string => {
   const unitTypes = UNITS.find((u) => u.parameterName === unit)?.unitTypes;
   if (!unitTypes) return value.toString();
   const type: UnitType | undefined = unitTypes.find(
     (t) => t.unitAbb === unitAbb
   );
-  if (type) return value.toFixed(type.unitPrecision);
+  if (type) return value.toFixed(decimals ?? type.unitPrecision);
   return value.toString();
 };
 


### PR DESCRIPTION
Enables observation values to be rounded to unit precision (by default) and to other precisions when an alternate precision is specified.

Addresses issue #355.