### PR TITLE
Enable selecting day length as shown/hidden in ForecastByHourList

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -103,6 +103,7 @@
       "relativeHumidity": "Relative humidity (%)",
       "pressure": "Pressure ({{ unit }})",
       "uvCumulated": "UV index",
+      "dayLength": "Day length",
       "selectAccessibilityHint": "Double tap to select parameter",
       "unSelectAccessibilityHint": "Double tap to deselect parameter",
       "restoreDefaultHint": "Restore default selection"

--- a/i18n/fi.json
+++ b/i18n/fi.json
@@ -103,6 +103,7 @@
       "relativeHumidity": "Suhteellinen kosteus (%)",
       "pressure": "Ilmanpaine ({{ unit }})",
       "uvCumulated": "UV indeksi",
+      "dayLength": "Päivän pituus",
       "selectAccessibilityHint": "Kaksoisnapauta valitaksesi",
       "unSelectAccessibilityHint": "Kaksoisnapauta poistaaksesi valinta",
       "restoreDefaultHint": "Palauta oletusvalinta"

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -103,6 +103,7 @@
       "relativeHumidity": "Relativ fuktighet (%)",
       "pressure": "Lufttryck ({{ unit }})",
       "uvCumulated": "UV index",
+      "dayLength": "Dagens längd",
       "selectAccessibilityHint": "Dubbelklicka för att välja",
       "unSelectAccessibilityHint": "Dubbelklicka för att ta bort valet",
       "restoreDefaultHint": "Återställ standardval"

--- a/src/components/weather/forecast/ForecastByHourList.tsx
+++ b/src/components/weather/forecast/ForecastByHourList.tsx
@@ -104,7 +104,7 @@ const ForecastByHourList: React.FC<ForecastByHourListProps> = ({
           styles.forecastHeader,
           {
             borderColor: colors.border,
-            backgroundColor: isOdd(displayParams.length)
+            backgroundColor: !isOdd(displayParams.length)
               ? colors.listTint
               : undefined,
           },

--- a/src/components/weather/forecast/ForecastByHourList.tsx
+++ b/src/components/weather/forecast/ForecastByHourList.tsx
@@ -25,6 +25,7 @@ import {
 } from '@utils/colors';
 
 import { isOdd } from '@utils/helpers';
+import { DAY_LENGTH } from '@store/forecast/constants';
 import ForecastListColumn from './ForecastListColumn';
 import ForecastListHeaderColumn from './ForecastListHeaderColumn';
 
@@ -349,7 +350,9 @@ const ForecastByHourList: React.FC<ForecastByHourListProps> = ({
           />
         </View>
       </View>
-      <DayDurationRow />
+      {displayParams
+        .map((displayParam) => displayParam[1])
+        .includes(DAY_LENGTH) && <DayDurationRow />}
       <LinearGradient
         pointerEvents="none"
         style={[styles.gradient, styles.gradientLeft]}

--- a/src/components/weather/forecast/ForecastListColumn.tsx
+++ b/src/components/weather/forecast/ForecastListColumn.tsx
@@ -60,218 +60,234 @@ const ForecastListColumn: React.FC<ForecastListColumnProps> = ({
           {time}
         </Text>
       </View>
-      {displayParams.map(([i, param], index) => {
-        if (param === constants.SMART_SYMBOL) {
-          return (
-            <View
-              key={`${param}-${i}`}
-              accessibilityLabel={`${t(`symbols:${data.smartSymbol}`)}.`}
-              style={[
-                styles.hourBlock,
-                { backgroundColor: isOdd(index) ? colors.listTint : undefined },
-              ]}>
-              {smartSymbol?.({
-                width: 40,
-                height: 40,
-              })}
-            </View>
-          );
-        }
-        if (param === constants.WIND_SPEED_AND_DIRECTION) {
-          const windSpeedUnit = Config.get('settings').units.wind;
-          const convertedWindSpeed =
-            data.windSpeedMS || data.windSpeedMS === 0
-              ? toPrecision(
-                  'wind',
-                  windSpeedUnit,
-                  converter(windSpeedUnit, data.windSpeedMS)
-                )
-              : '-';
-          return (
-            <View
-              accessibilityLabel={
-                data.windCompass8
-                  ? `${t(
-                      `observation:windDirection:${data.windCompass8}`
-                    )} ${convertedWindSpeed} ${t('forecast:metersPerSecond')}.`
-                  : `${convertedWindSpeed} ${t('forecast:metersPerSecond')}`
-              }
-              key={`${param}-${i}`}
-              style={[
-                styles.hourBlock,
-                { backgroundColor: isOdd(index) ? colors.listTint : undefined },
-              ]}>
-              {activeParameters.includes('windDirection') && (
-                <Icon
-                  name={dark ? 'wind-dark' : 'wind-light'}
-                  width={20}
-                  height={20}
-                  style={{
-                    transform: [
-                      {
-                        rotate: `${(data.windDirection || 0) + 45 - 180}deg`,
-                      },
-                    ],
-                  }}
-                />
-              )}
-              {activeParameters.includes('windSpeedMS') && (
+      {displayParams
+        .filter((displayParam) => displayParam[1] !== constants.DAY_LENGTH)
+        .map(([i, param], index) => {
+          if (param === constants.SMART_SYMBOL) {
+            return (
+              <View
+                key={`${param}-${i}`}
+                accessibilityLabel={`${t(`symbols:${data.smartSymbol}`)}.`}
+                style={[
+                  styles.hourBlock,
+                  {
+                    backgroundColor: isOdd(index) ? colors.listTint : undefined,
+                  },
+                ]}>
+                {smartSymbol?.({
+                  width: 40,
+                  height: 40,
+                })}
+              </View>
+            );
+          }
+          if (param === constants.WIND_SPEED_AND_DIRECTION) {
+            const windSpeedUnit = Config.get('settings').units.wind;
+            const convertedWindSpeed =
+              data.windSpeedMS || data.windSpeedMS === 0
+                ? toPrecision(
+                    'wind',
+                    windSpeedUnit,
+                    converter(windSpeedUnit, data.windSpeedMS)
+                  )
+                : '-';
+            return (
+              <View
+                accessibilityLabel={
+                  data.windCompass8
+                    ? `${t(
+                        `observation:windDirection:${data.windCompass8}`
+                      )} ${convertedWindSpeed} ${t(
+                        'forecast:metersPerSecond'
+                      )}.`
+                    : `${convertedWindSpeed} ${t('forecast:metersPerSecond')}`
+                }
+                key={`${param}-${i}`}
+                style={[
+                  styles.hourBlock,
+                  {
+                    backgroundColor: isOdd(index) ? colors.listTint : undefined,
+                  },
+                ]}>
+                {activeParameters.includes('windDirection') && (
+                  <Icon
+                    name={dark ? 'wind-dark' : 'wind-light'}
+                    width={20}
+                    height={20}
+                    style={{
+                      transform: [
+                        {
+                          rotate: `${(data.windDirection || 0) + 45 - 180}deg`,
+                        },
+                      ],
+                    }}
+                  />
+                )}
+                {activeParameters.includes('windSpeedMS') && (
+                  <Text
+                    style={[
+                      styles.regularText,
+                      styles.withMarginTop,
+                      { color: colors.hourListText },
+                    ]}>
+                    {convertedWindSpeed}
+                  </Text>
+                )}
+              </View>
+            );
+          }
+          if (param === constants.TEMPERATURE) {
+            const temperatureUnit = Config.get('settings').units.temperature;
+            const convertedTemperature =
+              data.temperature || data.temperature === 0
+                ? toPrecision(
+                    'temperature',
+                    temperatureUnit,
+                    converter(temperatureUnit, data.temperature)
+                  )
+                : '-';
+            return (
+              <View
+                key={`${param}-${i}`}
+                accessibilityLabel={t('forecast:params:temperature', {
+                  value: convertedTemperature,
+                })}
+                style={[
+                  styles.hourBlock,
+                  {
+                    backgroundColor: isOdd(index) ? colors.listTint : undefined,
+                  },
+                ]}>
+                <Text
+                  style={[styles.regularText, { color: colors.hourListText }]}>
+                  {`${convertedTemperature}°`}
+                </Text>
+              </View>
+            );
+          }
+          if (param === constants.FEELS_LIKE) {
+            const temperatureUnit = Config.get('settings').units.temperature;
+            const convertedFeelsLike =
+              data.feelsLike || data.feelsLike === 0
+                ? toPrecision(
+                    'temperature',
+                    temperatureUnit,
+                    converter(temperatureUnit, data.feelsLike)
+                  )
+                : '-';
+            return (
+              <View
+                key={`${param}-${i}`}
+                accessibilityLabel={t('forecast:params:feelsLike', {
+                  value: convertedFeelsLike,
+                })}
+                style={[
+                  styles.hourBlock,
+                  {
+                    backgroundColor: isOdd(index) ? colors.listTint : undefined,
+                  },
+                ]}>
                 <Text
                   style={[
                     styles.regularText,
-                    styles.withMarginTop,
                     { color: colors.hourListText },
-                  ]}>
-                  {convertedWindSpeed}
-                </Text>
-              )}
-            </View>
-          );
-        }
-        if (param === constants.TEMPERATURE) {
-          const temperatureUnit = Config.get('settings').units.temperature;
-          const convertedTemperature =
-            data.temperature || data.temperature === 0
-              ? toPrecision(
-                  'temperature',
-                  temperatureUnit,
-                  converter(temperatureUnit, data.temperature)
-                )
+                  ]}>{`${convertedFeelsLike}°`}</Text>
+              </View>
+            );
+          }
+
+          if (param === constants.DEW_POINT) {
+            const temperatureUnit = Config.get('settings').units.temperature;
+            const convertedDewPoint =
+              data.dewPoint || data.dewPoint === 0
+                ? toPrecision(
+                    'temperature',
+                    temperatureUnit,
+                    converter(temperatureUnit, data.dewPoint)
+                  )
+                : '-';
+            return (
+              <View
+                key={`${param}-${i}`}
+                style={[
+                  styles.hourBlock,
+                  {
+                    backgroundColor: isOdd(index) ? colors.listTint : undefined,
+                  },
+                ]}>
+                <Text
+                  accessibilityLabel={t('forecast:params:dewpoint', {
+                    value: convertedDewPoint,
+                  })}
+                  style={[
+                    styles.regularText,
+                    { color: colors.hourListText },
+                  ]}>{`${convertedDewPoint}°`}</Text>
+              </View>
+            );
+          }
+
+          if (param === constants.PRESSURE) {
+            const pressureUnit = Config.get('settings').units.pressure;
+            const convertedPressure =
+              data.pressure || data.pressure === 0
+                ? toPrecision(
+                    'pressure',
+                    pressureUnit,
+                    converter(pressureUnit, data.pressure)
+                  )
+                : '-';
+            return (
+              <View
+                key={`${param}-${i}`}
+                style={[
+                  styles.hourBlock,
+                  {
+                    backgroundColor: isOdd(index) ? colors.listTint : undefined,
+                  },
+                ]}>
+                <Text
+                  accessibilityLabel={t('forecast:params:pressure', {
+                    value: convertedPressure,
+                  })}
+                  style={[
+                    styles.regularText,
+                    { color: colors.hourListText },
+                  ]}>{`${convertedPressure}`}</Text>
+              </View>
+            );
+          }
+
+          const toDisplay =
+            data[String(param)] !== null && data[String(param)] !== undefined
+              ? data[String(param)]
               : '-';
+
+          const precipitationUnit = Config.get('settings').units.precipitation;
+
           return (
             <View
               key={`${param}-${i}`}
-              accessibilityLabel={t('forecast:params:temperature', {
-                value: convertedTemperature,
-              })}
               style={[
                 styles.hourBlock,
                 { backgroundColor: isOdd(index) ? colors.listTint : undefined },
               ]}>
               <Text
+                accessibilityLabel={t(`forecast:params:${param}`, {
+                  value: toDisplay,
+                })}
                 style={[styles.regularText, { color: colors.hourListText }]}>
-                {`${convertedTemperature}°`}
+                {param === constants.PRECIPITATION_1H &&
+                typeof toDisplay === 'number' &&
+                toDisplay >= 0
+                  ? `${converter(precipitationUnit, toDisplay).toFixed(
+                      1
+                    )}`.replace('.', ',')
+                  : toDisplay}
               </Text>
             </View>
           );
-        }
-        if (param === constants.FEELS_LIKE) {
-          const temperatureUnit = Config.get('settings').units.temperature;
-          const convertedFeelsLike =
-            data.feelsLike || data.feelsLike === 0
-              ? toPrecision(
-                  'temperature',
-                  temperatureUnit,
-                  converter(temperatureUnit, data.feelsLike)
-                )
-              : '-';
-          return (
-            <View
-              key={`${param}-${i}`}
-              accessibilityLabel={t('forecast:params:feelsLike', {
-                value: convertedFeelsLike,
-              })}
-              style={[
-                styles.hourBlock,
-                { backgroundColor: isOdd(index) ? colors.listTint : undefined },
-              ]}>
-              <Text
-                style={[
-                  styles.regularText,
-                  { color: colors.hourListText },
-                ]}>{`${convertedFeelsLike}°`}</Text>
-            </View>
-          );
-        }
-
-        if (param === constants.DEW_POINT) {
-          const temperatureUnit = Config.get('settings').units.temperature;
-          const convertedDewPoint =
-            data.dewPoint || data.dewPoint === 0
-              ? toPrecision(
-                  'temperature',
-                  temperatureUnit,
-                  converter(temperatureUnit, data.dewPoint)
-                )
-              : '-';
-          return (
-            <View
-              key={`${param}-${i}`}
-              style={[
-                styles.hourBlock,
-                { backgroundColor: isOdd(index) ? colors.listTint : undefined },
-              ]}>
-              <Text
-                accessibilityLabel={t('forecast:params:dewpoint', {
-                  value: convertedDewPoint,
-                })}
-                style={[
-                  styles.regularText,
-                  { color: colors.hourListText },
-                ]}>{`${convertedDewPoint}°`}</Text>
-            </View>
-          );
-        }
-
-        if (param === constants.PRESSURE) {
-          const pressureUnit = Config.get('settings').units.pressure;
-          const convertedPressure =
-            data.pressure || data.pressure === 0
-              ? toPrecision(
-                  'pressure',
-                  pressureUnit,
-                  converter(pressureUnit, data.pressure)
-                )
-              : '-';
-          return (
-            <View
-              key={`${param}-${i}`}
-              style={[
-                styles.hourBlock,
-                { backgroundColor: isOdd(index) ? colors.listTint : undefined },
-              ]}>
-              <Text
-                accessibilityLabel={t('forecast:params:pressure', {
-                  value: convertedPressure,
-                })}
-                style={[
-                  styles.regularText,
-                  { color: colors.hourListText },
-                ]}>{`${convertedPressure}`}</Text>
-            </View>
-          );
-        }
-
-        const toDisplay =
-          data[String(param)] !== null && data[String(param)] !== undefined
-            ? data[String(param)]
-            : '-';
-
-        const precipitationUnit = Config.get('settings').units.precipitation;
-
-        return (
-          <View
-            key={`${param}-${i}`}
-            style={[
-              styles.hourBlock,
-              { backgroundColor: isOdd(index) ? colors.listTint : undefined },
-            ]}>
-            <Text
-              accessibilityLabel={t(`forecast:params:${param}`, {
-                value: toDisplay,
-              })}
-              style={[styles.regularText, { color: colors.hourListText }]}>
-              {param === constants.PRECIPITATION_1H &&
-              typeof toDisplay === 'number' &&
-              toDisplay >= 0
-                ? `${converter(precipitationUnit, toDisplay).toFixed(
-                    1
-                  )}`.replace('.', ',')
-                : toDisplay}
-            </Text>
-          </View>
-        );
-      })}
+        })}
     </View>
   );
 };

--- a/src/components/weather/forecast/ForecastListHeaderColumn.tsx
+++ b/src/components/weather/forecast/ForecastListHeaderColumn.tsx
@@ -33,129 +33,152 @@ const ForecastListHeaderColumn: React.FC<ForecastListHeaderColumnProps> = ({
       <View style={[styles.hourBlock, { backgroundColor: colors.listTint }]}>
         <Icon name="clock" color={colors.hourListText} />
       </View>
-      {displayParams.map(([i, param], index) => {
-        if (param === constants.WIND_SPEED_AND_DIRECTION) {
-          return (
-            <View
-              key={`${param}-${i}`}
-              style={[
-                styles.hourBlock,
-                { backgroundColor: isOdd(index) ? colors.listTint : undefined },
-              ]}>
-              <Icon name="wind" color={colors.hourListText} />
-              <Text style={[styles.panelText, { color: colors.hourListText }]}>
-                {units.wind}
-              </Text>
-            </View>
-          );
-        }
-        if (param === constants.WIND_GUST) {
-          return (
-            <View
-              key={`${param}-${i}`}
-              style={[
-                styles.hourBlock,
-                { backgroundColor: isOdd(index) ? colors.listTint : undefined },
-              ]}>
-              <Icon name="gust" color={colors.hourListText} />
-              <Text style={[styles.panelText, { color: colors.hourListText }]}>
-                {units.wind}
-              </Text>
-            </View>
-          );
-        }
-        if (param === constants.PRECIPITATION_1H) {
-          return (
-            <View
-              key={`${param}-${i}`}
-              style={[
-                styles.hourBlock,
-                { backgroundColor: isOdd(index) ? colors.listTint : undefined },
-              ]}>
-              <Icon name="precipitation" color={colors.hourListText} />
-              <Text style={[styles.panelText, { color: colors.hourListText }]}>
-                {units.precipitation}
-              </Text>
-            </View>
-          );
-        }
+      {displayParams
+        .filter((displayParam) => displayParam[1] !== constants.DAY_LENGTH)
+        .map(([i, param], index) => {
+          if (param === constants.WIND_SPEED_AND_DIRECTION) {
+            return (
+              <View
+                key={`${param}-${i}`}
+                style={[
+                  styles.hourBlock,
+                  {
+                    backgroundColor: isOdd(index) ? colors.listTint : undefined,
+                  },
+                ]}>
+                <Icon name="wind" color={colors.hourListText} />
+                <Text
+                  style={[styles.panelText, { color: colors.hourListText }]}>
+                  {units.wind}
+                </Text>
+              </View>
+            );
+          }
+          if (param === constants.WIND_GUST) {
+            return (
+              <View
+                key={`${param}-${i}`}
+                style={[
+                  styles.hourBlock,
+                  {
+                    backgroundColor: isOdd(index) ? colors.listTint : undefined,
+                  },
+                ]}>
+                <Icon name="gust" color={colors.hourListText} />
+                <Text
+                  style={[styles.panelText, { color: colors.hourListText }]}>
+                  {units.wind}
+                </Text>
+              </View>
+            );
+          }
+          if (param === constants.PRECIPITATION_1H) {
+            return (
+              <View
+                key={`${param}-${i}`}
+                style={[
+                  styles.hourBlock,
+                  {
+                    backgroundColor: isOdd(index) ? colors.listTint : undefined,
+                  },
+                ]}>
+                <Icon name="precipitation" color={colors.hourListText} />
+                <Text
+                  style={[styles.panelText, { color: colors.hourListText }]}>
+                  {units.precipitation}
+                </Text>
+              </View>
+            );
+          }
 
-        if (param === constants.PRECIPITATION_PROBABILITY) {
+          if (param === constants.PRECIPITATION_PROBABILITY) {
+            return (
+              <View
+                key={`${param}-${i}`}
+                style={[
+                  styles.hourBlock,
+                  styles.row,
+                  {
+                    backgroundColor: isOdd(index) ? colors.listTint : undefined,
+                  },
+                ]}>
+                <Icon name="precipitation" color={colors.hourListText} />
+                <Text
+                  style={[styles.panelText, { color: colors.hourListText }]}>
+                  %
+                </Text>
+              </View>
+            );
+          }
+
+          if (param === constants.RELATIVE_HUMIDITY) {
+            return (
+              <View
+                key={`${param}-${i}`}
+                style={[
+                  styles.hourBlock,
+                  {
+                    backgroundColor: isOdd(index) ? colors.listTint : undefined,
+                  },
+                ]}>
+                <Text
+                  style={[styles.panelText, { color: colors.hourListText }]}>
+                  RH%
+                </Text>
+              </View>
+            );
+          }
+
+          if (param === constants.PRESSURE) {
+            return (
+              <View
+                key={`${param}-${i}`}
+                style={[
+                  styles.hourBlock,
+                  {
+                    backgroundColor: isOdd(index) ? colors.listTint : undefined,
+                  },
+                ]}>
+                <Text
+                  style={[styles.panelText, { color: colors.hourListText }]}>
+                  {units.pressure}
+                </Text>
+              </View>
+            );
+          }
+
+          if (param === constants.UV_CUMULATED) {
+            return (
+              <View
+                key={`${param}-${i}`}
+                style={[
+                  styles.hourBlock,
+                  {
+                    backgroundColor: isOdd(index) ? colors.listTint : undefined,
+                  },
+                ]}>
+                <Text
+                  style={[styles.panelText, { color: colors.hourListText }]}>
+                  UV
+                </Text>
+              </View>
+            );
+          }
+
           return (
             <View
               key={`${param}-${i}`}
               style={[
                 styles.hourBlock,
-                styles.row,
                 { backgroundColor: isOdd(index) ? colors.listTint : undefined },
               ]}>
-              <Icon name="precipitation" color={colors.hourListText} />
-              <Text style={[styles.panelText, { color: colors.hourListText }]}>
-                %
-              </Text>
+              <Icon
+                name={constants.PARAMS_TO_ICONS[String(param)]}
+                color={colors.hourListText}
+              />
             </View>
           );
-        }
-
-        if (param === constants.RELATIVE_HUMIDITY) {
-          return (
-            <View
-              key={`${param}-${i}`}
-              style={[
-                styles.hourBlock,
-                { backgroundColor: isOdd(index) ? colors.listTint : undefined },
-              ]}>
-              <Text style={[styles.panelText, { color: colors.hourListText }]}>
-                RH%
-              </Text>
-            </View>
-          );
-        }
-
-        if (param === constants.PRESSURE) {
-          return (
-            <View
-              key={`${param}-${i}`}
-              style={[
-                styles.hourBlock,
-                { backgroundColor: isOdd(index) ? colors.listTint : undefined },
-              ]}>
-              <Text style={[styles.panelText, { color: colors.hourListText }]}>
-                {units.pressure}
-              </Text>
-            </View>
-          );
-        }
-
-        if (param === constants.UV_CUMULATED) {
-          return (
-            <View
-              key={`${param}-${i}`}
-              style={[
-                styles.hourBlock,
-                { backgroundColor: isOdd(index) ? colors.listTint : undefined },
-              ]}>
-              <Text style={[styles.panelText, { color: colors.hourListText }]}>
-                UV
-              </Text>
-            </View>
-          );
-        }
-
-        return (
-          <View
-            key={`${param}-${i}`}
-            style={[
-              styles.hourBlock,
-              { backgroundColor: isOdd(index) ? colors.listTint : undefined },
-            ]}>
-            <Icon
-              name={constants.PARAMS_TO_ICONS[String(param)]}
-              color={colors.hourListText}
-            />
-          </View>
-        );
-      })}
+        })}
     </View>
   );
 };

--- a/src/components/weather/sheets/ParamsBottomSheet.tsx
+++ b/src/components/weather/sheets/ParamsBottomSheet.tsx
@@ -26,6 +26,7 @@ import constants, {
   PRESSURE,
   UV_CUMULATED,
   PARAMS_TO_ICONS,
+  DAY_LENGTH,
 } from '@store/forecast/constants';
 
 import { useOrientation } from '@utils/hooks';
@@ -70,7 +71,7 @@ const ParamsBottomSheet: React.FC<ParamsBottomSheetProps> = ({
   } = Config.get('weather').forecast;
   const activeParameters = data.flatMap(({ parameters }) => parameters);
 
-  const regex = new RegExp(activeParameters.join('|'));
+  const regex = new RegExp([...activeParameters, DAY_LENGTH].join('|'));
   const activeConstants = constants.filter((constant) =>
     regex.test(constant)
   ) as DisplayParameters[];

--- a/src/store/forecast/constants.ts
+++ b/src/store/forecast/constants.ts
@@ -10,6 +10,7 @@ export const DEW_POINT = 'dewPoint';
 export const RELATIVE_HUMIDITY = 'relativeHumidity';
 export const PRESSURE = 'pressure';
 export const UV_CUMULATED = 'uvCumulated';
+export const DAY_LENGTH = 'dayLength';
 
 export const PARAMS_TO_ICONS = {
   smartSymbol: 'weather-symbol',
@@ -20,6 +21,7 @@ export const PARAMS_TO_ICONS = {
   precipitation1h: 'precipitation',
   pop: 'precipitation',
   dewPoint: 'dew-point',
+  dayLength: 'time',
 } as { [key: string]: string };
 
 export default [
@@ -35,4 +37,5 @@ export default [
   RELATIVE_HUMIDITY,
   PRESSURE,
   UV_CUMULATED,
+  DAY_LENGTH,
 ];

--- a/src/store/forecast/selectors.ts
+++ b/src/store/forecast/selectors.ts
@@ -7,7 +7,7 @@ import { Config } from '@config';
 import { getIndexForDaySmartSymbol } from '@utils/helpers';
 import { State } from '../types';
 import { DisplayParameters, ForecastState, TimeStepData } from './types';
-import constants from './constants';
+import constants, { DAY_LENGTH } from './constants';
 
 const selectForecastDomain: Selector<State, ForecastState> = (state) =>
   state.forecast;
@@ -166,9 +166,8 @@ export const selectDisplayParams = createSelector(
   (forecast) => {
     const { data, defaultParameters } = Config.get('weather').forecast;
     const regex = new RegExp(
-      data.flatMap(({ parameters }) => parameters).join('|')
+      [...data.flatMap(({ parameters }) => parameters), DAY_LENGTH].join('|')
     );
-
     return (
       forecast.displayParams.length > 0
         ? forecast.displayParams


### PR DESCRIPTION
Enables toggling the visibility of day length in ForecastByHourList.
Related issue: #359 