### PR TITLE
Fix English weekday abbreviations

### DIFF
--- a/src/components/map/ui/TimeSlider.tsx
+++ b/src/components/map/ui/TimeSlider.tsx
@@ -96,10 +96,12 @@ const TimeSlider: React.FC<TimeSliderProps> = ({
       Number(moment(overlay.observation.end).format('X'))) ||
     0;
 
+  const weekdayAbbreviationFormat = locale === 'en' ? 'ddd' : 'dd';
+
   const currentSliderTime = moment
     .unix(sliderTime)
     .locale(locale)
-    .format('dd HH:mm');
+    .format(`${weekdayAbbreviationFormat} HH:mm`);
 
   const { sliderStep, sliderTimes } = useMemo(() => {
     const minUnix = getSliderMinUnix(activeOverlayId, overlay);

--- a/src/components/warnings/WarningsPanel.tsx
+++ b/src/components/warnings/WarningsPanel.tsx
@@ -73,6 +73,9 @@ const WarningsPanel: React.FC<WarningsPanelProps> = ({
     return null;
   }
 
+  const locale = i18n.language;
+  const weekdayAbbreviationFormat = locale === 'en' ? 'ddd' : 'dd';
+
   return (
     <View
       style={[
@@ -199,7 +202,7 @@ const WarningsPanel: React.FC<WarningsPanelProps> = ({
                           color: colors.text,
                         },
                       ]}>
-                      {moment(date).format('dd')}
+                      {moment(date).format(weekdayAbbreviationFormat)}
                     </Text>
                     <Text
                       style={[

--- a/src/components/weather/charts/Chart.tsx
+++ b/src/components/weather/charts/Chart.tsx
@@ -196,6 +196,7 @@ const Chart: React.FC<ChartProps> = ({
             chartType={chartType}
             Component={Component}
             chartValues={chartValues}
+            locale={i18n.language}
           />
         </ScrollView>
         <ChartYAxis

--- a/src/components/weather/charts/ChartDataRenderer.tsx
+++ b/src/components/weather/charts/ChartDataRenderer.tsx
@@ -4,7 +4,7 @@ import { VictoryAxis, VictoryChart } from 'victory-native';
 import moment from 'moment';
 import { useTheme } from '@react-navigation/native';
 import { CustomTheme } from '@utils/colors';
-import { tickFormat } from '@utils/chart';
+import { getTickFormat } from '@utils/chart';
 import { ChartDataProps, ChartDomain, ChartType, ChartValues } from './types';
 
 type ChartDataRendererProps = {
@@ -14,6 +14,7 @@ type ChartDataRendererProps = {
   chartType: ChartType;
   chartValues: ChartValues;
   Component: React.FC<ChartDataProps>;
+  locale: string;
 };
 const ChartDataRenderer: React.FC<ChartDataRendererProps> = ({
   chartDimensions,
@@ -22,6 +23,7 @@ const ChartDataRenderer: React.FC<ChartDataRendererProps> = ({
   chartType,
   chartValues,
   Component,
+  locale,
 }) => {
   const { colors } = useTheme() as CustomTheme;
 
@@ -41,7 +43,7 @@ const ChartDataRenderer: React.FC<ChartDataRendererProps> = ({
       scale={{ x: 'linear' }}>
       <VictoryAxis
         scale={{ x: 'linear' }}
-        tickFormat={tickFormat}
+        tickFormat={getTickFormat(locale)}
         tickValues={tickValues}
         orientation="bottom"
         style={{

--- a/src/components/weather/forecast/DaySelectorList.tsx
+++ b/src/components/weather/forecast/DaySelectorList.tsx
@@ -88,6 +88,8 @@ const DaySelectorList: React.FC<DaySelectorListProps> = ({
       converter(temperatureUnit, minTemperature)
     );
 
+    const weekdayAbbreviationFormat = locale === 'en' ? 'ddd' : 'dd';
+
     return (
       <View
         key={timeStamp}
@@ -116,7 +118,7 @@ const DaySelectorList: React.FC<DaySelectorListProps> = ({
             accessibilityLabel={stepMoment
               .locale(locale)
               .format('dddd, Do MMMM')}>
-            {stepMoment.locale(locale).format('dd')}{' '}
+            {stepMoment.locale(locale).format(weekdayAbbreviationFormat)}{' '}
             <Text style={[styles.bold, { color: colors.primaryText }]}>
               {stepMoment.locale(locale).format('D.M.')}
             </Text>

--- a/src/components/weather/observation/Latest.tsx
+++ b/src/components/weather/observation/Latest.tsx
@@ -21,12 +21,14 @@ const Latest: React.FC<LatestProps> = ({ data }) => {
   const locale = i18n.language;
   const { parameters } = Config.get('weather').observation;
 
+  const weekdayAbbreviationFormat = locale === 'en' ? 'ddd' : 'dd';
+
   const [latestObservation] = data || [];
   const latestObservationTime =
     latestObservation &&
     moment(latestObservation.epochtime * 1000)
       .locale(locale)
-      .format(`dd D.M. [${t('at')}] HH:mm`);
+      .format(`${weekdayAbbreviationFormat} D.M. [${t('at')}] HH:mm`);
 
   const latestParameters: {
     [key in keyof Partial<ObservationParameters>]: {

--- a/src/utils/chart.ts
+++ b/src/utils/chart.ts
@@ -90,7 +90,7 @@ export const chartTickValues = (
 export const capitalize = ([first, ...rest]: string) =>
   first.toUpperCase() + rest.join('');
 
-export const tickFormat = (tick: any): string | number => {
+export const tickFormat = (tick: any, locale: string): string | number => {
   const time = moment(tick);
   const hour = time.hour();
   const minutes = time.minutes();
@@ -99,11 +99,14 @@ export const tickFormat = (tick: any): string | number => {
     return '';
   }
   if (hour === 0) {
-    return `${capitalize(time.format('dd'))}
+    return `${capitalize(time.format(locale === 'en' ? 'ddd' : 'dd'))}
 ${time.format('D.M.')}`;
   }
   return time.format('HH');
 };
+
+export const getTickFormat = (locale: string) => (tick: any) =>
+  tickFormat(tick, locale);
 
 export const chartYLabelText = (chartType: ChartType) => {
   const { units } = Config.get('settings');


### PR DESCRIPTION
Fixes weekday abbreviations to use 3 characters instead of 2 when English is chosen as the application's language,

Related issue: #352