### PR TITLE
Make warning information available to screen readers in TabNavigator

### DIFF
--- a/src/navigators/TabNavigator.tsx
+++ b/src/navigators/TabNavigator.tsx
@@ -125,6 +125,7 @@ const Navigator: React.FC<Props> = ({
 
   const [useDarkTheme, setUseDarkTheme] = useState<boolean>(isDark(theme));
   const [didChangeLanguage, setDidChangeLanguage] = useState<boolean>(false);
+  const [warningsSeverity, setWarningsSeverity] = useState<number>(0);
 
   const handleLanguageChanged = useCallback(() => {
     setDidChangeLanguage(true);
@@ -504,12 +505,20 @@ const Navigator: React.FC<Props> = ({
             options={{
               tabBarAccessibilityLabel: `${t('navigation:warnings')}, 3 ${t(
                 'navigation:slash'
-              )} 4`,
+              )} 4, ${t(
+                warningsSeverity > 0
+                  ? 'warnings:hasWarnings'
+                  : 'warnings:noWarnings'
+              )}`,
               headerShown: false,
               tabBarTestID: 'navigation_warnings',
               tabBarLabel: `${t('navigation:warnings')}`,
               tabBarIcon: ({ color, size }) => (
-                <WarningsTabIcon color={color} size={size} />
+                <WarningsTabIcon
+                  color={color}
+                  size={size}
+                  updateWarningsSeverity={setWarningsSeverity}
+                />
               ),
             }}
           />

--- a/src/navigators/WarningsTabIcon.tsx
+++ b/src/navigators/WarningsTabIcon.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import Icon from '@components/common/Icon';
 
 import { selectCurrentDayWarningData } from '@store/warnings/selectors';
@@ -26,6 +26,7 @@ type Props = {
   color: string;
   size: number;
   warningData: WarningData[];
+  updateWarningsSeverity: Function;
 };
 
 const getIconName = (severity: number, dark: boolean): string => {
@@ -41,8 +42,18 @@ const getIconName = (severity: number, dark: boolean): string => {
   }
 };
 
-const WarningsTabIcon: React.FC<Props> = ({ color, size, warningData }) => {
+const WarningsTabIcon: React.FC<Props> = ({
+  color,
+  size,
+  warningData,
+  updateWarningsSeverity,
+}) => {
   const { dark } = useTheme();
+
+  useEffect(() => {
+    updateWarningsSeverity(warningData[0].severity);
+  }, [warningData, updateWarningsSeverity]);
+
   return (
     <Icon
       name={getIconName(warningData[0].severity, dark)}


### PR DESCRIPTION
Makes warning information available to screen readers in TabNavigator.

Related issue: #361 