### PR TITLE
Enable setting default clock type in config

### DIFF
--- a/__tests__/config/testConfig.ts
+++ b/__tests__/config/testConfig.ts
@@ -112,6 +112,7 @@ const defaultConfig: ConfigType = {
     enabled: false,
   },
   socialMediaLinks: [],
+  clockType: 24,
 };
 
 export default defaultConfig;

--- a/__tests__/config/testConfig.ts
+++ b/__tests__/config/testConfig.ts
@@ -107,12 +107,12 @@ const defaultConfig: ConfigType = {
       wind: 'm/s',
       pressure: 'hPa',
     },
+    clockType: 24,
   },
   announcements: {
     enabled: false,
   },
   socialMediaLinks: [],
-  clockType: 24,
 };
 
 export default defaultConfig;

--- a/__tests__/store/settings.test.ts
+++ b/__tests__/store/settings.test.ts
@@ -54,7 +54,7 @@ describe('settings reducer', () => {
     ).toEqual({
       units: undefined,
       theme: 'light',
-      clockType: 24,
+      clockType: undefined,
     });
   });
 

--- a/defaultConfig.ts.example
+++ b/defaultConfig.ts.example
@@ -79,6 +79,7 @@ const defaultConfig: ConfigType = {
       wind: 'm/s',
       pressure: 'hPa',
     },
+    clockType: 24,
   },
   announcements: {
     enabled: true,

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -161,4 +161,5 @@ export interface ConfigType {
   announcements: AnnouncementsEnabled | AnnouncementsDisabled;
   socialMediaLinks: SocialMediaLink[];
   unresolvedGeoIdErrorMessage?: UnresolvedGeoIdErrorMessage;
+  clockType: 12 | 24;
 }

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -157,9 +157,9 @@ export interface ConfigType {
       wind: 'm/s' | 'km/h' | 'mph' | 'bft' | 'kn';
       pressure: 'hPa' | 'inHg' | 'mmHg' | 'mbar';
     };
+    clockType: 12 | 24;
   };
   announcements: AnnouncementsEnabled | AnnouncementsDisabled;
   socialMediaLinks: SocialMediaLink[];
   unresolvedGeoIdErrorMessage?: UnresolvedGeoIdErrorMessage;
-  clockType: 12 | 24;
 }

--- a/src/store/settings/reducer.ts
+++ b/src/store/settings/reducer.ts
@@ -11,7 +11,7 @@ import {
 const INITIAL_STATE: SettingsState = {
   units: getDefaultUnits(),
   theme: 'automatic',
-  clockType: 24,
+  clockType: undefined,
 };
 
 export default (

--- a/src/store/settings/selectors.ts
+++ b/src/store/settings/selectors.ts
@@ -1,3 +1,4 @@
+import { Config } from '@config';
 import { Selector, createSelector } from 'reselect';
 import { State } from '../types';
 import { SettingsState } from './types';
@@ -17,5 +18,8 @@ export const selectTheme = createSelector(
 
 export const selectClockType = createSelector(
   selectSettingsDomain,
-  (settings) => settings.clockType
+  (settings) => {
+    const configClockType = Config.get('clockType');
+    return settings.clockType ?? configClockType;
+  }
 );

--- a/src/store/settings/selectors.ts
+++ b/src/store/settings/selectors.ts
@@ -19,7 +19,7 @@ export const selectTheme = createSelector(
 export const selectClockType = createSelector(
   selectSettingsDomain,
   (settings) => {
-    const configClockType = Config.get('clockType');
+    const configClockType = Config.get('settings').clockType;
     return settings.clockType ?? configClockType;
   }
 );

--- a/src/store/settings/types.ts
+++ b/src/store/settings/types.ts
@@ -46,7 +46,7 @@ export type SettingsActionTypes =
   | UpdateClockType;
 
 export interface SettingsState {
-  clockType: ClockType;
+  clockType?: ClockType;
   units: UnitMap | undefined;
   theme: Theme;
 }


### PR DESCRIPTION
Adds a property `clockType` in the config to enable setting the default clock type.

Resolves issue #387.