### PR TITLE
Announce selected day in forecast panel

### DIFF
--- a/src/components/weather/forecast/DaySelectorList.tsx
+++ b/src/components/weather/forecast/DaySelectorList.tsx
@@ -108,7 +108,9 @@ const DaySelectorList: React.FC<DaySelectorListProps> = ({
             borderTopColor: isActive ? colors.tabBarActive : colors.border,
           },
         ]}>
-        <AccessibleTouchableOpacity onPress={() => setActiveDayIndex(index)}>
+        <AccessibleTouchableOpacity
+          accessibilityState={{ selected: isActive }}
+          onPress={() => setActiveDayIndex(index)}>
           <Text
             style={[
               styles.dateText,


### PR DESCRIPTION
Improves the accessibility of the day selectors in the forecast panel by announcing whether or not the date read by a screen reader has been selected.