### PR TITLE
Fix date and time formats in WarningsPanel and DayDetails

### DIFF
--- a/src/components/warnings/DayDetails.tsx
+++ b/src/components/warnings/DayDetails.tsx
@@ -26,12 +26,13 @@ type DayDetailsProps = PropsFromRedux & {
 };
 
 const DayDetails: React.FC<DayDetailsProps> = ({ clockType, warnings }) => {
-  const { t } = useTranslation('warnings');
+  const { t, i18n } = useTranslation('warnings');
   const { colors } = useTheme() as CustomTheme;
   const [openWarnings, setOpenWarnings] = useState<{
     [index: number]: boolean;
   }>([]);
 
+  const locale = i18n.language;
   const timeFormat = clockType === 12 ? 'h.mm a' : 'HH.mm';
 
   useEffect(() => {
@@ -80,9 +81,13 @@ const DayDetails: React.FC<DayDetailsProps> = ({ clockType, warnings }) => {
                   )}`}>
                   <Text style={styles.bold}>{`${t(`types.${type}`)}`}</Text>
                   {` – ${t('valid')} ${moment(duration.startTime).format(
-                    `D.M. ${timeFormat}`
+                    locale === 'en'
+                      ? `MMM D ${timeFormat}`
+                      : `D.M. ${timeFormat}`
                   )} - ${moment(duration.endTime).format(
-                    `D.M. ${timeFormat}`
+                    locale === 'en'
+                      ? `MMM D ${timeFormat}`
+                      : `D.M. ${timeFormat}`
                   )} `}
                 </Text>
               </View>

--- a/src/components/warnings/WarningsPanel.tsx
+++ b/src/components/warnings/WarningsPanel.tsx
@@ -78,10 +78,11 @@ const WarningsPanel: React.FC<WarningsPanelProps> = ({
 
   const locale = i18n.language;
   const weekdayAbbreviationFormat = locale === 'en' ? 'ddd' : 'dd';
-  const lastUpdatedDateTimeFormat =
-    clockType === 12
-      ? `D.M. [${t('forecast:at')}] h.mm a`
-      : `D.M. [${t('forecast:at')}] HH.mm`;
+  const timeFormat = clockType === 12 ? 'h.mm ' : 'HH.mm';
+  const dateFormat = locale === 'en' ? 'MMM D' : 'D.M.';
+  const lastUpdatedDateTimeFormat = `${dateFormat} [${t(
+    'forecast:at'
+  )}] ${timeFormat}`;
   return (
     <View
       style={[
@@ -219,7 +220,7 @@ const WarningsPanel: React.FC<WarningsPanelProps> = ({
                           color: colors.text,
                         },
                       ]}>
-                      {moment(date).format('D.M.')}
+                      {moment(date).format(locale === 'en' ? 'MMM D' : 'D.M.')}
                     </Text>
                     <SeverityBar severity={severity} />
                   </View>


### PR DESCRIPTION
Fixes English date formats and 12-hour time formats in warnings screen (WarningsPanel and DayDetails).

Resolves issue #397.