### PR TITLE
Fix smart symbol selection logic in DaySelector

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -287,10 +287,16 @@ export const getIndexForDaySmartSymbol = (
   dayArray: TimeStepData[],
   dayIndex: number
 ): number => {
+  if (dayArray.length === 24) {
+    return 14; // choose 14:00 (2.00 PM) local time as the default time
+  }
+  if (dayArray.length >= 10) {
+    return 14 - (24 - dayArray.length); // choose index of 14:00 if available from a list with fewer than 24 hourly forecasts
+  }
   const index = dayArray.findIndex((d) => {
     const dateObj = new Date(d.epochtime * 1000);
-    const utcHours = dateObj.getUTCHours();
-    return utcHours === 12;
+    const hours = dateObj.getHours();
+    return hours === 14;
   });
 
   if (dayIndex === 0 && index < 0) {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -287,13 +287,10 @@ export const getIndexForDaySmartSymbol = (
   dayArray: TimeStepData[],
   dayIndex: number
 ): number => {
-  if (dayArray.length === 24) {
-    return 16;
-  }
   const index = dayArray.findIndex((d) => {
     const dateObj = new Date(d.epochtime * 1000);
-    const hours = dateObj.getHours();
-    return hours === 15;
+    const utcHours = dateObj.getUTCHours();
+    return utcHours === 12;
   });
 
   if (dayIndex === 0 && index < 0) {


### PR DESCRIPTION
Fix logic for choosing the smart symbol shown in day selector. The smart symbol should be chosen for the forecast at 14:00/2.00 PM if available.