### PR TITLE
Hide observation parameter selectors for parameters with no data

### DIFF
--- a/src/components/weather/ObservationPanel.tsx
+++ b/src/components/weather/ObservationPanel.tsx
@@ -253,14 +253,22 @@ const ObservationPanel: React.FC<ObservationPanelProps> = ({
         <View style={styles.observationContainer}>
           <ParameterSelector
             chartTypes={charts}
-            parameter={parameter}
+            parameter={charts.includes(parameter) ? parameter : charts[0]}
             setParameter={updateChartParameter}
           />
           {displayFormat === LIST && (
-            <List data={data} parameter={parameter} clockType={clockType} />
+            <List
+              data={data}
+              parameter={charts.includes(parameter) ? parameter : charts[0]}
+              clockType={clockType}
+            />
           )}
           {displayFormat === CHART && (
-            <Chart chartType={parameter} data={data} observation />
+            <Chart
+              chartType={charts.includes(parameter) ? parameter : charts[0]}
+              data={data}
+              observation
+            />
           )}
         </View>
       )}

--- a/src/components/weather/ObservationPanel.tsx
+++ b/src/components/weather/ObservationPanel.tsx
@@ -108,9 +108,23 @@ const ObservationPanel: React.FC<ObservationPanelProps> = ({
     'cloud',
     'snowDepth',
   ];
+
   charts = charts.filter((type) => {
     const typeParameters = observationTypeParameters[type];
+    const dataForParameter = typeParameters.map((typeParam) =>
+      data.map(
+        (dataPoint) => dataPoint[typeParam as keyof ObservationParameters]
+      )
+    );
+    const observationDataExistsForParameter = dataForParameter.some(
+      (parameterData) =>
+        parameterData.some(
+          (dataPoint) => dataPoint !== null && dataPoint !== undefined
+        )
+    );
+
     return (
+      observationDataExistsForParameter &&
       typeParameters.filter((typeParameter) =>
         parameters?.includes(typeParameter as keyof ObservationParameters)
       ).length > 0

--- a/src/components/weather/observation/Latest.tsx
+++ b/src/components/weather/observation/Latest.tsx
@@ -127,6 +127,8 @@ const Latest: React.FC<LatestProps> = ({ clockType, data }) => {
           } (${value})`;
         }
 
+        if (value === '-') return null;
+
         return (
           <View key={parameter} style={styles.observationRow} accessible>
             <View style={styles.flex}>


### PR DESCRIPTION
Resolves #414, #415.

Removes observation parameter selector buttons for parameters that are not measured by an observation station (i.e. no data exists for a given parameter).