### PR TITLE
Show dash if UV is null or undefined

### DIFF
--- a/src/components/weather/NextHourForecastPanel.tsx
+++ b/src/components/weather/NextHourForecastPanel.tsx
@@ -257,11 +257,11 @@ const NextHourForecastPanel: React.FC<NextHourForecastPanelProps> = ({
             <Text
               style={[styles.text, { color: colors.hourListText }]}
               accessibilityLabel={t('params.uvCumulated', {
-                value: numericOrDash(`${nextHourForecast.uvCumulated}`),
+                value: numericOrDash(nextHourForecast.uvCumulated?.toString()),
               })}>
               {'UV '}
               <Text style={styles.bold}>
-                {numericOrDash(`${nextHourForecast.uvCumulated}`)}
+                {numericOrDash(nextHourForecast.uvCumulated?.toString())}
               </Text>
             </Text>
           )}


### PR DESCRIPTION
Show "-" instead of null when the UV value received from the server is null.