### PR TITLE
Enable configuring use of onboarding wizard

### DIFF
--- a/__tests__/config/testConfig.ts
+++ b/__tests__/config/testConfig.ts
@@ -117,6 +117,9 @@ const defaultConfig: ConfigType = {
     enabled: false,
   },
   socialMediaLinks: [],
+  onboardingWizard: {
+    enabled: true,
+  },
 };
 
 export default defaultConfig;

--- a/defaultConfig.ts.example
+++ b/defaultConfig.ts.example
@@ -101,6 +101,9 @@ const defaultConfig: ConfigType = {
       url: 'https://www.socialmedia.example',
     },
   ],
+  onboardingWizard: {
+    enabled: true,
+  }
 };
 
 export default defaultConfig;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -130,6 +130,10 @@ interface DarkThemeEnabled {
 
 type Themes = LightThemeEnabled | DarkThemeEnabled;
 
+interface OnboardingWizard {
+  enabled: boolean;
+}
+
 export interface ConfigType {
   dynamicConfig: DynamicConfigEnabled | DynamicConfigDisabled;
   location: {
@@ -175,4 +179,5 @@ export interface ConfigType {
   announcements: AnnouncementsEnabled | AnnouncementsDisabled;
   socialMediaLinks: SocialMediaLink[];
   unresolvedGeoIdErrorMessage?: UnresolvedGeoIdErrorMessage;
+  onboardingWizard: OnboardingWizard;
 }

--- a/src/navigators/TabNavigator.tsx
+++ b/src/navigators/TabNavigator.tsx
@@ -126,7 +126,7 @@ const Navigator: React.FC<Props> = ({
       Appearance.getColorScheme() === 'dark');
 
   const warningsEnabled = Config.get('warnings').enabled;
-
+  const onboardingWizardEnabled = Config.get('onboardingWizard').enabled;
   const [useDarkTheme, setUseDarkTheme] = useState<boolean>(isDark(theme));
   const [didChangeLanguage, setDidChangeLanguage] = useState<boolean>(false);
   const [warningsSeverity, setWarningsSeverity] = useState<number>(0);
@@ -416,7 +416,7 @@ const Navigator: React.FC<Props> = ({
     return null;
   }
 
-  if (!didLaunchApp) {
+  if (!didLaunchApp && onboardingWizardEnabled) {
     return (
       <NavigationContainer theme={useDarkTheme ? darkTheme : lightTheme}>
         <SetupStackScreen />


### PR DESCRIPTION
Resolves #445.

Enables configuring onboarding wizard to be skipped and therefore not shown to the user.