### PR TITLE
Make visibility of day length configurable

### DIFF
--- a/src/components/weather/forecast/ForecastByHourList.tsx
+++ b/src/components/weather/forecast/ForecastByHourList.tsx
@@ -27,6 +27,7 @@ import {
 import { isOdd } from '@utils/helpers';
 import { DAY_LENGTH } from '@store/forecast/constants';
 import { selectClockType } from '@store/settings/selectors';
+import { Config } from '@config';
 import ForecastListColumn from './ForecastListColumn';
 import ForecastListHeaderColumn from './ForecastListHeaderColumn';
 
@@ -59,6 +60,7 @@ const ForecastByHourList: React.FC<ForecastByHourListProps> = ({
   const [currentIndex, setCurrentIndex] = useState<number>(0);
   const { colors, dark } = useTheme() as CustomTheme;
   const { t } = useTranslation('forecast');
+  const { excludeDayLength } = Config.get('weather').forecast;
 
   const virtualizedList = useRef() as React.MutableRefObject<
     VirtualizedList<TimeStepData>
@@ -366,7 +368,8 @@ const ForecastByHourList: React.FC<ForecastByHourListProps> = ({
       </View>
       {displayParams
         .map((displayParam) => displayParam[1])
-        .includes(DAY_LENGTH) && <DayDurationRow />}
+        .includes(DAY_LENGTH) &&
+        !excludeDayLength && <DayDurationRow />}
       <LinearGradient
         pointerEvents="none"
         style={[styles.gradient, styles.gradientLeft]}

--- a/src/components/weather/sheets/ParamsBottomSheet.tsx
+++ b/src/components/weather/sheets/ParamsBottomSheet.tsx
@@ -68,10 +68,16 @@ const ParamsBottomSheet: React.FC<ParamsBottomSheetProps> = ({
   const {
     data,
     defaultParameters: [defaultParameter],
+    excludeDayLength,
   } = Config.get('weather').forecast;
   const activeParameters = data.flatMap(({ parameters }) => parameters);
 
-  const regex = new RegExp([...activeParameters, DAY_LENGTH].join('|'));
+  const regex = new RegExp(
+    (excludeDayLength
+      ? [...activeParameters]
+      : [...activeParameters, DAY_LENGTH]
+    ).join('|')
+  );
   const activeConstants = constants.filter((constant) =>
     regex.test(constant)
   ) as DisplayParameters[];

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -182,6 +182,7 @@ export interface ConfigType {
         parameters: (keyof ForecastParameters)[];
       }[];
       defaultParameters: DisplayParameters[];
+      excludeDayLength?: boolean;
     };
     observation: ObservationEnabled | ObservationDisabled;
   };


### PR DESCRIPTION
Introduces a config option for excluding day length from the parameters shown in the forecast view and parameter selection sheet.