### PR TITLE
Cap improvements

### DIFF
--- a/src/components/warnings/cap/MapView.tsx
+++ b/src/components/warnings/cap/MapView.tsx
@@ -45,17 +45,17 @@ const MapView = ({
     const dayStart = date.hours(0).minutes(0);
     const dayEnd = date.clone().add(1, 'days');
     const warnings = capData?.filter((warning) => {
-      const onsetMoment = moment(warning.info.onset);
+      const effectiveMoment = moment(warning.info.effective);
       const expiryMoment = moment(warning.info.expires);
 
       const endsDuringDay =
-        onsetMoment.isBefore(dayStart) && expiryMoment.isAfter(dayStart);
+        effectiveMoment.isBefore(dayStart) && expiryMoment.isAfter(dayStart);
       const isContainedInDay =
-        onsetMoment.isAfter(dayStart) && expiryMoment.isBefore(dayEnd);
+        effectiveMoment.isAfter(dayStart) && expiryMoment.isBefore(dayEnd);
       const startsDuringDay =
-        onsetMoment.isBefore(dayEnd) && expiryMoment.isAfter(dayEnd);
+        effectiveMoment.isBefore(dayEnd) && expiryMoment.isAfter(dayEnd);
       const dayContained =
-        onsetMoment.isBefore(dayStart) && expiryMoment.isAfter(dayEnd);
+        effectiveMoment.isBefore(dayStart) && expiryMoment.isAfter(dayEnd);
 
       return (
         endsDuringDay || isContainedInDay || startsDuringDay || dayContained

--- a/src/components/warnings/cap/WarningBlock.tsx
+++ b/src/components/warnings/cap/WarningBlock.tsx
@@ -168,13 +168,13 @@ function WarningBlock({
 
   const getHeaderWarningTimeSpans = (capWarnings: CapWarning[]): string[] => {
     const timespans = capWarnings.map((warning) => ({
-      onset: warning.info.onset,
+      effective: warning.info.effective,
       expiry: warning.info.expires,
     }));
     timespans.sort(
       (span1, span2) =>
-        moment(span1.onset).toDate().getTime() -
-        moment(span2.onset).toDate().getTime()
+        moment(span1.effective).toDate().getTime() -
+        moment(span2.effective).toDate().getTime()
     );
     const intervals = [];
 
@@ -187,7 +187,7 @@ function WarningBlock({
       // Get all timespans that begin before current has ended
 
       if (
-        moment(span.onset).toDate().getTime() <
+        moment(span.effective).toDate().getTime() <
         moment(currentTimespan.expiry).toDate().getTime()
       ) {
         spans.push({
@@ -198,7 +198,7 @@ function WarningBlock({
       } else {
         const lastToExpire = Math.max(...spans.map((s) => s.time));
         intervals.push({
-          onset: moment(currentTimespan.onset),
+          effective: moment(currentTimespan.effective),
           expiry: moment(lastToExpire),
         });
         currentTimespan = timespans[index];
@@ -210,22 +210,22 @@ function WarningBlock({
 
     if (currentTimespan && (spans.length === 0 || intervals.length === 0)) {
       intervals.push({
-        onset: moment(currentTimespan.onset),
+        effective: moment(currentTimespan.effective),
         expiry: moment(currentTimespan.expiry),
       });
     }
 
-    return intervals.map(({ onset, expiry }) => {
-      const onsetFormatted = onset
+    return intervals.map(({ effective, expiry }) => {
+      const effectiveFormatted = effective
         .locale(locale)
         .format(`${weekdayAbbreviationFormat} ${dateFormat}`);
 
-      if (onset.isSame(expiry, 'day')) return onsetFormatted;
+      if (effective.isSame(expiry, 'day')) return effectiveFormatted;
 
       const expiryFormatted = expiry
         .locale(locale)
         .format(`${weekdayAbbreviationFormat} ${dateFormat}`);
-      return `${onsetFormatted} - ${expiryFormatted}`;
+      return `${effectiveFormatted} - ${expiryFormatted}`;
     });
   };
   const headerTimeSpanString = [
@@ -233,7 +233,7 @@ function WarningBlock({
   ].join(', ');
 
   const warningTimeSpans = warnings.map((warning) => {
-    const start = moment(warning.info.onset);
+    const start = moment(warning.info.effective);
     const end = moment(warning.info.expires);
     const startFormatted = start
       .locale(locale)

--- a/src/network/CapWarningsApi.ts
+++ b/src/network/CapWarningsApi.ts
@@ -4,6 +4,32 @@ import axiosClient from '@utils/axiosClient';
 import { parse } from 'fast-xml-parser';
 import moment from 'moment';
 
+const isRelevantMessage = (warning: CapWarning) => {
+  const isActual = warning.status === 'Actual';
+  const isPublic = warning.scope === 'Public';
+  const isMet = warning.info.category === 'Met';
+  const isAckOrError = ['Ack', 'Error'].includes(warning.msgType);
+  const hasValidUrgency = ['Immediate', 'Expected', 'Future'].includes(
+    warning.info.urgency
+  );
+  const hasArea =
+    Boolean(warning.info.area?.polygon) || Boolean(warning.info.area?.circle);
+  const hasExpired = moment(warning.info.expires).isBefore(moment.now());
+
+  return (
+    isActual &&
+    isPublic &&
+    isMet &&
+    !isAckOrError &&
+    hasValidUrgency &&
+    hasArea &&
+    !hasExpired
+  );
+};
+
+const parseReferences = (references: string) =>
+  references.split(' ').map((ref) => ref.split(',')[1]);
+
 const getCapWarnings = async () => {
   const { capViewSettings } = Config.get('warnings');
 
@@ -21,10 +47,28 @@ const getCapWarnings = async () => {
     )
   ).map(({ data }) => parse(data).alert);
 
-  const activeWarnings = capWarnings.filter(
-    (warning) => !moment(warning.info.expires).isBefore(moment.now())
+  const relevantMessages = capWarnings.filter(isRelevantMessage);
+  const updatedMessages = relevantMessages
+    .filter((message) => message.msgType === 'Update')
+    .map((message) => parseReferences(message.references))
+    .flat();
+
+  const canceledMessages = relevantMessages
+    .filter((message) => message.msgType === 'Cancel')
+    .map((message) => parseReferences(message.references))
+    .flat();
+
+  relevantMessages.filter(
+    (message) =>
+      ![...updatedMessages, ...canceledMessages].includes(message.identifier)
   );
-  return activeWarnings;
+
+  const finalMessages = relevantMessages.filter(
+    (message) =>
+      ![...updatedMessages, ...canceledMessages].includes(message.identifier)
+  );
+
+  return { updated: feed.updated, warnings: finalMessages };
 };
 
 export default getCapWarnings;

--- a/src/store/warnings/actions.ts
+++ b/src/store/warnings/actions.ts
@@ -34,11 +34,11 @@ const fetchCapWarnings = () => (dispatch: Dispatch<WarningsActionTypes>) => {
   dispatch({ type: FETCH_CAP_WARNINGS });
 
   getCapWarnings()
-    .then((capData) => {
+    .then((data) => {
       dispatch({
         type: FETCH_CAP_WARNINGS_SUCCESS,
-        data: capData,
-        timestamp: Date.now(),
+        data: data.warnings,
+        timestamp: data.updated,
       });
     })
     .catch((error: Error) => {

--- a/src/store/warnings/types.ts
+++ b/src/store/warnings/types.ts
@@ -63,6 +63,7 @@ export interface CapWarning {
   status: string;
   msgType: string;
   scope: string;
+  references: string;
   info: {
     language: string;
     category: string;
@@ -79,6 +80,7 @@ export interface CapWarning {
     area: {
       areaDesc: string;
       polygon: string;
+      circle: string;
     };
   };
 }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -318,11 +318,11 @@ const getSeveritiesForTimePeriod = (
 ) => {
   const severitiesForTimePeriod = warnings
     ?.filter((warning) => {
-      const onset = moment(warning.info.onset);
+      const effective = moment(warning.info.effective);
       const expires = moment(warning.info.expires);
-      const beginsDuringPeriod = onset.isBetween(start, end);
+      const beginsDuringPeriod = effective.isBetween(start, end);
       const endsDuringPeriod = expires.isBetween(start, end);
-      const periodContained = onset.isBefore(start) && expires.isAfter(end);
+      const periodContained = effective.isBefore(start) && expires.isAfter(end);
       return beginsDuringPeriod || endsDuringPeriod || periodContained;
     })
     .map((warning) => severities.indexOf(warning.info.severity) + 1);


### PR DESCRIPTION
Relates to issue #433.

Changes:
- use `effective` field instead of `onset` field in CAP message as the start time of the warning
- change the "Updated" date shown in UI to be the date reported in the CAP message
- add logic for disregarding irrelevant messages and handling messages of types "Update", "Cancel"