### PR TITLE
Enable configuring automatic visibility of all weather symbols

### DIFF
--- a/defaultConfig.ts.example
+++ b/defaultConfig.ts.example
@@ -54,6 +54,10 @@ const defaultConfig: ConfigType = {
       forecastLengthTitle: 10, // optional, defaults to 10
       data: [{ producer: 'default', parameters: ['temperature'] }],
       defaultParameters: ['temperature'],
+      excludeDayLength: false,
+      infoBottomSheet: {
+        showAllSymbols: false,
+      }
     },
     observation: {
       enabled: true,

--- a/src/components/weather/sheets/WeatherInfoBottomSheet.tsx
+++ b/src/components/weather/sheets/WeatherInfoBottomSheet.tsx
@@ -58,7 +58,9 @@ const WeatherInfoBottomSheet: React.FC<WeatherInfoBottomSheetProps> = ({
   uniqueSmartSymbols,
   onClose,
 }) => {
-  const [symbolsOpen, setSymbolsOpen] = useState<boolean>(false);
+  const showAllSymbols =
+    Config.get('weather').forecast.infoBottomSheet?.showAllSymbols || false;
+  const [symbolsOpen, setSymbolsOpen] = useState<boolean>(showAllSymbols);
   const { t } = useTranslation('forecast');
   const { colors, dark } = useTheme() as CustomTheme;
   const isLandscape = useOrientation();
@@ -885,32 +887,35 @@ const WeatherInfoBottomSheet: React.FC<WeatherInfoBottomSheetProps> = ({
                   )
                 )}
             </View>
-            <AccessibleTouchableOpacity
-              style={[
-                styles.row,
-                styles.buttonContainer,
-                {
-                  borderColor: colors.primaryText,
-                },
-              ]}
-              onPress={() => setSymbolsOpen((prev) => !prev)}>
-              <Text style={[styles.buttonText, { color: colors.primaryText }]}>
-                {!symbolsOpen
-                  ? `${t('weatherInfoBottomSheet.showRest')} (${
-                      filteredSymbolsArr.length - currentSymbols
-                    })`
-                  : t('weatherInfoBottomSheet.showLess')}
-              </Text>
-              <Icon
-                name={symbolsOpen ? 'arrow-up' : 'arrow-down'}
-                width={24}
-                height={24}
+            {!showAllSymbols && (
+              <AccessibleTouchableOpacity
                 style={[
-                  styles.withSmallMarginLeft,
-                  { color: colors.primaryText },
+                  styles.row,
+                  styles.buttonContainer,
+                  {
+                    borderColor: colors.primaryText,
+                  },
                 ]}
-              />
-            </AccessibleTouchableOpacity>
+                onPress={() => setSymbolsOpen((prev) => !prev)}>
+                <Text
+                  style={[styles.buttonText, { color: colors.primaryText }]}>
+                  {!symbolsOpen
+                    ? `${t('weatherInfoBottomSheet.showRest')} (${
+                        filteredSymbolsArr.length - currentSymbols
+                      })`
+                    : t('weatherInfoBottomSheet.showLess')}
+                </Text>
+                <Icon
+                  name={symbolsOpen ? 'arrow-up' : 'arrow-down'}
+                  width={24}
+                  height={24}
+                  style={[
+                    styles.withSmallMarginLeft,
+                    { color: colors.primaryText },
+                  ]}
+                />
+              </AccessibleTouchableOpacity>
+            )}
           </TouchableOpacity>
         </ScrollView>
       </View>

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -183,6 +183,9 @@ export interface ConfigType {
       }[];
       defaultParameters: DisplayParameters[];
       excludeDayLength?: boolean;
+      infoBottomSheet?: {
+        showAllSymbols?: boolean;
+      };
     };
     observation: ObservationEnabled | ObservationDisabled;
   };


### PR DESCRIPTION
Resolves issue #464.

Adds a configuration option that enables showing all weather symbols in info bottom sheet automatically without having to a press a button.