### PR TITLE
Only show one filter button per event/severity combination

### DIFF
--- a/src/components/warnings/cap/MapView.tsx
+++ b/src/components/warnings/cap/MapView.tsx
@@ -62,7 +62,21 @@ const MapView = ({
       );
     });
 
-    return warnings;
+    const uniqueWarnings: CapWarning[] = [];
+
+    warnings?.forEach((warning) => {
+      if (
+        !uniqueWarnings.find(
+          (w) =>
+            w.info.event === warning.info.event &&
+            w.info.severity === warning.info.severity
+        )
+      ) {
+        uniqueWarnings.push(warning);
+      }
+    });
+
+    return uniqueWarnings;
   }, [capData, date]);
 
   useEffect(() => setSelectedFilters([]), [date]);


### PR DESCRIPTION
Fixes CAP map view to only show one filter button per event-severity combination. Currently a filter button is displayed for all warnings, which sometimes results in many identical buttons being rendered.