### PR TITLE
Make showing location in CAP text list configurable

### DIFF
--- a/src/components/warnings/cap/CapWarningsView.tsx
+++ b/src/components/warnings/cap/CapWarningsView.tsx
@@ -47,6 +47,14 @@ const CapWarningsView: React.FC<CapWarningsViewProps> = ({
   const { colors } = useTheme() as CustomTheme;
 
   const capViewSettings = Config.get('warnings')?.capViewSettings;
+
+  let textViewTitle = `${t('warningsForNDays', {
+    days: capViewSettings?.numberOfDays,
+  })}`;
+
+  if (capViewSettings?.includeAreaInTitle)
+    textViewTitle += ` - ${currentLocation?.name}`;
+
   const getDateIndicatorDates = () => {
     const today = moment(new Date()).hours(12).minutes(0);
     const dates = [
@@ -132,12 +140,7 @@ const CapWarningsView: React.FC<CapWarningsViewProps> = ({
           </View>
         </View>
         <MapView dates={dates} capData={capWarnings} />
-        <PanelHeader
-          title={`${t('warningsForNDays', {
-            days: capViewSettings?.numberOfDays,
-          })} - ${currentLocation?.name}`}
-          justifyCenter
-        />
+        <PanelHeader title={textViewTitle} justifyCenter />
         <TextList capData={capWarnings} dates={dates} />
       </View>
       <RBSheet

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -78,6 +78,7 @@ interface CapViewSettings {
   mapZoomEnabled?: boolean;
   mapScrollEnabled?: boolean;
   mapToolbarEnabled?: boolean;
+  includeAreaInTitle?: boolean;
 }
 
 interface Warnings {


### PR DESCRIPTION
Enables configuring the visibility of current location in the CAP warnings text list view title.

Resolves https://github.com/smartmet-jm/weather-app/issues/32.