### PR TITLE
Fix error when CAP feed contains no alerts

### DIFF
--- a/src/network/CapWarningsApi.ts
+++ b/src/network/CapWarningsApi.ts
@@ -45,7 +45,9 @@ const getCapWarnings = async () => {
         })
       )
     )
-  ).map(({ data }) => parse(data).alert);
+  )
+    .map(({ data }) => parse(data).alert)
+    .filter((warning) => warning); // remove undefined, null
 
   const relevantMessages = capWarnings.filter(isRelevantMessage);
   const updatedMessages = relevantMessages


### PR DESCRIPTION
Fixes CapWarningsApi to disregard messages that do not contain an alert. This fixes https://github.com/smartmet-jm/weather-app/issues/34.