### PR TITLE
Jamaica issue 10 - setting for using cardinals instead of degrees on wind direction

### DIFF
--- a/ios/MobileWeather.xcodeproj/project.pbxproj
+++ b/ios/MobileWeather.xcodeproj/project.pbxproj
@@ -786,7 +786,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 228;
-				DEVELOPMENT_TEAM = DJHT89EW79;
+				DEVELOPMENT_TEAM = ;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = MobileWeather/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -816,7 +816,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 228;
-				DEVELOPMENT_TEAM = DJHT89EW79;
+				DEVELOPMENT_TEAM = ;
 				INFOPLIST_FILE = MobileWeather/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/ios/MobileWeather.xcodeproj/project.pbxproj
+++ b/ios/MobileWeather.xcodeproj/project.pbxproj
@@ -786,7 +786,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 228;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = DJHT89EW79;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = MobileWeather/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -816,7 +816,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 228;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = DJHT89EW79;
 				INFOPLIST_FILE = MobileWeather/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/ios/MobileWeather.xcodeproj/project.pbxproj
+++ b/ios/MobileWeather.xcodeproj/project.pbxproj
@@ -786,7 +786,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 228;
-				DEVELOPMENT_TEAM = ;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = MobileWeather/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
@@ -816,7 +816,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 228;
-				DEVELOPMENT_TEAM = ;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = MobileWeather/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -3,14 +3,14 @@ PODS:
   - BVLinearGradient (2.5.6):
     - React
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.66.3)
-  - FBReactNativeSpec (0.66.3):
+  - FBLazyVector (0.66.5)
+  - FBReactNativeSpec (0.66.5):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.66.3)
-    - RCTTypeSafety (= 0.66.3)
-    - React-Core (= 0.66.3)
-    - React-jsi (= 0.66.3)
-    - ReactCommon/turbomodule/core (= 0.66.3)
+    - RCTRequired (= 0.66.5)
+    - RCTTypeSafety (= 0.66.5)
+    - React-Core (= 0.66.5)
+    - React-jsi (= 0.66.5)
+    - ReactCommon/turbomodule/core (= 0.66.5)
   - fmt (6.2.1)
   - glog (0.3.5)
   - hermes-engine (0.9.0)
@@ -36,203 +36,203 @@ PODS:
     - fmt (~> 6.2.1)
     - glog
     - libevent
-  - RCTRequired (0.66.3)
-  - RCTTypeSafety (0.66.3):
-    - FBLazyVector (= 0.66.3)
+  - RCTRequired (0.66.5)
+  - RCTTypeSafety (0.66.5):
+    - FBLazyVector (= 0.66.5)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.66.3)
-    - React-Core (= 0.66.3)
-  - React (0.66.3):
-    - React-Core (= 0.66.3)
-    - React-Core/DevSupport (= 0.66.3)
-    - React-Core/RCTWebSocket (= 0.66.3)
-    - React-RCTActionSheet (= 0.66.3)
-    - React-RCTAnimation (= 0.66.3)
-    - React-RCTBlob (= 0.66.3)
-    - React-RCTImage (= 0.66.3)
-    - React-RCTLinking (= 0.66.3)
-    - React-RCTNetwork (= 0.66.3)
-    - React-RCTSettings (= 0.66.3)
-    - React-RCTText (= 0.66.3)
-    - React-RCTVibration (= 0.66.3)
-  - React-callinvoker (0.66.3)
-  - React-Core (0.66.3):
+    - RCTRequired (= 0.66.5)
+    - React-Core (= 0.66.5)
+  - React (0.66.5):
+    - React-Core (= 0.66.5)
+    - React-Core/DevSupport (= 0.66.5)
+    - React-Core/RCTWebSocket (= 0.66.5)
+    - React-RCTActionSheet (= 0.66.5)
+    - React-RCTAnimation (= 0.66.5)
+    - React-RCTBlob (= 0.66.5)
+    - React-RCTImage (= 0.66.5)
+    - React-RCTLinking (= 0.66.5)
+    - React-RCTNetwork (= 0.66.5)
+    - React-RCTSettings (= 0.66.5)
+    - React-RCTText (= 0.66.5)
+    - React-RCTVibration (= 0.66.5)
+  - React-callinvoker (0.66.5)
+  - React-Core (0.66.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.66.3)
-    - React-cxxreact (= 0.66.3)
-    - React-jsi (= 0.66.3)
-    - React-jsiexecutor (= 0.66.3)
-    - React-perflogger (= 0.66.3)
+    - React-Core/Default (= 0.66.5)
+    - React-cxxreact (= 0.66.5)
+    - React-jsi (= 0.66.5)
+    - React-jsiexecutor (= 0.66.5)
+    - React-perflogger (= 0.66.5)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.66.3):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default
-    - React-cxxreact (= 0.66.3)
-    - React-jsi (= 0.66.3)
-    - React-jsiexecutor (= 0.66.3)
-    - React-perflogger (= 0.66.3)
-    - Yoga
-  - React-Core/Default (0.66.3):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.66.3)
-    - React-jsi (= 0.66.3)
-    - React-jsiexecutor (= 0.66.3)
-    - React-perflogger (= 0.66.3)
-    - Yoga
-  - React-Core/DevSupport (0.66.3):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.66.3)
-    - React-Core/RCTWebSocket (= 0.66.3)
-    - React-cxxreact (= 0.66.3)
-    - React-jsi (= 0.66.3)
-    - React-jsiexecutor (= 0.66.3)
-    - React-jsinspector (= 0.66.3)
-    - React-perflogger (= 0.66.3)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.66.3):
+  - React-Core/CoreModulesHeaders (0.66.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.3)
-    - React-jsi (= 0.66.3)
-    - React-jsiexecutor (= 0.66.3)
-    - React-perflogger (= 0.66.3)
+    - React-cxxreact (= 0.66.5)
+    - React-jsi (= 0.66.5)
+    - React-jsiexecutor (= 0.66.5)
+    - React-perflogger (= 0.66.5)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.66.3):
+  - React-Core/Default (0.66.5):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-cxxreact (= 0.66.5)
+    - React-jsi (= 0.66.5)
+    - React-jsiexecutor (= 0.66.5)
+    - React-perflogger (= 0.66.5)
+    - Yoga
+  - React-Core/DevSupport (0.66.5):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-Core/Default (= 0.66.5)
+    - React-Core/RCTWebSocket (= 0.66.5)
+    - React-cxxreact (= 0.66.5)
+    - React-jsi (= 0.66.5)
+    - React-jsiexecutor (= 0.66.5)
+    - React-jsinspector (= 0.66.5)
+    - React-perflogger (= 0.66.5)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.66.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.3)
-    - React-jsi (= 0.66.3)
-    - React-jsiexecutor (= 0.66.3)
-    - React-perflogger (= 0.66.3)
+    - React-cxxreact (= 0.66.5)
+    - React-jsi (= 0.66.5)
+    - React-jsiexecutor (= 0.66.5)
+    - React-perflogger (= 0.66.5)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.66.3):
+  - React-Core/RCTAnimationHeaders (0.66.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.3)
-    - React-jsi (= 0.66.3)
-    - React-jsiexecutor (= 0.66.3)
-    - React-perflogger (= 0.66.3)
+    - React-cxxreact (= 0.66.5)
+    - React-jsi (= 0.66.5)
+    - React-jsiexecutor (= 0.66.5)
+    - React-perflogger (= 0.66.5)
     - Yoga
-  - React-Core/RCTImageHeaders (0.66.3):
+  - React-Core/RCTBlobHeaders (0.66.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.3)
-    - React-jsi (= 0.66.3)
-    - React-jsiexecutor (= 0.66.3)
-    - React-perflogger (= 0.66.3)
+    - React-cxxreact (= 0.66.5)
+    - React-jsi (= 0.66.5)
+    - React-jsiexecutor (= 0.66.5)
+    - React-perflogger (= 0.66.5)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.66.3):
+  - React-Core/RCTImageHeaders (0.66.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.3)
-    - React-jsi (= 0.66.3)
-    - React-jsiexecutor (= 0.66.3)
-    - React-perflogger (= 0.66.3)
+    - React-cxxreact (= 0.66.5)
+    - React-jsi (= 0.66.5)
+    - React-jsiexecutor (= 0.66.5)
+    - React-perflogger (= 0.66.5)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.66.3):
+  - React-Core/RCTLinkingHeaders (0.66.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.3)
-    - React-jsi (= 0.66.3)
-    - React-jsiexecutor (= 0.66.3)
-    - React-perflogger (= 0.66.3)
+    - React-cxxreact (= 0.66.5)
+    - React-jsi (= 0.66.5)
+    - React-jsiexecutor (= 0.66.5)
+    - React-perflogger (= 0.66.5)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.66.3):
+  - React-Core/RCTNetworkHeaders (0.66.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.3)
-    - React-jsi (= 0.66.3)
-    - React-jsiexecutor (= 0.66.3)
-    - React-perflogger (= 0.66.3)
+    - React-cxxreact (= 0.66.5)
+    - React-jsi (= 0.66.5)
+    - React-jsiexecutor (= 0.66.5)
+    - React-perflogger (= 0.66.5)
     - Yoga
-  - React-Core/RCTTextHeaders (0.66.3):
+  - React-Core/RCTSettingsHeaders (0.66.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.3)
-    - React-jsi (= 0.66.3)
-    - React-jsiexecutor (= 0.66.3)
-    - React-perflogger (= 0.66.3)
+    - React-cxxreact (= 0.66.5)
+    - React-jsi (= 0.66.5)
+    - React-jsiexecutor (= 0.66.5)
+    - React-perflogger (= 0.66.5)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.66.3):
+  - React-Core/RCTTextHeaders (0.66.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.66.3)
-    - React-jsi (= 0.66.3)
-    - React-jsiexecutor (= 0.66.3)
-    - React-perflogger (= 0.66.3)
+    - React-cxxreact (= 0.66.5)
+    - React-jsi (= 0.66.5)
+    - React-jsiexecutor (= 0.66.5)
+    - React-perflogger (= 0.66.5)
     - Yoga
-  - React-Core/RCTWebSocket (0.66.3):
+  - React-Core/RCTVibrationHeaders (0.66.5):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.66.3)
-    - React-cxxreact (= 0.66.3)
-    - React-jsi (= 0.66.3)
-    - React-jsiexecutor (= 0.66.3)
-    - React-perflogger (= 0.66.3)
+    - React-Core/Default
+    - React-cxxreact (= 0.66.5)
+    - React-jsi (= 0.66.5)
+    - React-jsiexecutor (= 0.66.5)
+    - React-perflogger (= 0.66.5)
     - Yoga
-  - React-CoreModules (0.66.3):
-    - FBReactNativeSpec (= 0.66.3)
+  - React-Core/RCTWebSocket (0.66.5):
+    - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.3)
-    - React-Core/CoreModulesHeaders (= 0.66.3)
-    - React-jsi (= 0.66.3)
-    - React-RCTImage (= 0.66.3)
-    - ReactCommon/turbomodule/core (= 0.66.3)
-  - React-cxxreact (0.66.3):
+    - React-Core/Default (= 0.66.5)
+    - React-cxxreact (= 0.66.5)
+    - React-jsi (= 0.66.5)
+    - React-jsiexecutor (= 0.66.5)
+    - React-perflogger (= 0.66.5)
+    - Yoga
+  - React-CoreModules (0.66.5):
+    - FBReactNativeSpec (= 0.66.5)
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - RCTTypeSafety (= 0.66.5)
+    - React-Core/CoreModulesHeaders (= 0.66.5)
+    - React-jsi (= 0.66.5)
+    - React-RCTImage (= 0.66.5)
+    - ReactCommon/turbomodule/core (= 0.66.5)
+  - React-cxxreact (0.66.5):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.66.3)
-    - React-jsi (= 0.66.3)
-    - React-jsinspector (= 0.66.3)
-    - React-logger (= 0.66.3)
-    - React-perflogger (= 0.66.3)
-    - React-runtimeexecutor (= 0.66.3)
-  - React-hermes (0.66.3):
+    - React-callinvoker (= 0.66.5)
+    - React-jsi (= 0.66.5)
+    - React-jsinspector (= 0.66.5)
+    - React-logger (= 0.66.5)
+    - React-perflogger (= 0.66.5)
+    - React-runtimeexecutor (= 0.66.5)
+  - React-hermes (0.66.5):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2021.06.28.00-v2)
     - RCT-Folly/Futures (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.66.3)
-    - React-jsi (= 0.66.3)
-    - React-jsiexecutor (= 0.66.3)
-    - React-jsinspector (= 0.66.3)
-    - React-perflogger (= 0.66.3)
-  - React-jsi (0.66.3):
+    - React-cxxreact (= 0.66.5)
+    - React-jsi (= 0.66.5)
+    - React-jsiexecutor (= 0.66.5)
+    - React-jsinspector (= 0.66.5)
+    - React-perflogger (= 0.66.5)
+  - React-jsi (0.66.5):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-jsi/Default (= 0.66.3)
-  - React-jsi/Default (0.66.3):
+    - React-jsi/Default (= 0.66.5)
+  - React-jsi/Default (0.66.5):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-  - React-jsiexecutor (0.66.3):
+  - React-jsiexecutor (0.66.5):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.66.3)
-    - React-jsi (= 0.66.3)
-    - React-perflogger (= 0.66.3)
-  - React-jsinspector (0.66.3)
-  - React-logger (0.66.3):
+    - React-cxxreact (= 0.66.5)
+    - React-jsi (= 0.66.5)
+    - React-perflogger (= 0.66.5)
+  - React-jsinspector (0.66.5)
+  - React-logger (0.66.5):
     - glog
   - react-native-config (1.4.5):
     - react-native-config/App (= 1.4.5)
@@ -254,71 +254,71 @@ PODS:
     - React-Core
   - react-native-webview (11.15.0):
     - React-Core
-  - React-perflogger (0.66.3)
-  - React-RCTActionSheet (0.66.3):
-    - React-Core/RCTActionSheetHeaders (= 0.66.3)
-  - React-RCTAnimation (0.66.3):
-    - FBReactNativeSpec (= 0.66.3)
+  - React-perflogger (0.66.5)
+  - React-RCTActionSheet (0.66.5):
+    - React-Core/RCTActionSheetHeaders (= 0.66.5)
+  - React-RCTAnimation (0.66.5):
+    - FBReactNativeSpec (= 0.66.5)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.3)
-    - React-Core/RCTAnimationHeaders (= 0.66.3)
-    - React-jsi (= 0.66.3)
-    - ReactCommon/turbomodule/core (= 0.66.3)
-  - React-RCTBlob (0.66.3):
-    - FBReactNativeSpec (= 0.66.3)
+    - RCTTypeSafety (= 0.66.5)
+    - React-Core/RCTAnimationHeaders (= 0.66.5)
+    - React-jsi (= 0.66.5)
+    - ReactCommon/turbomodule/core (= 0.66.5)
+  - React-RCTBlob (0.66.5):
+    - FBReactNativeSpec (= 0.66.5)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/RCTBlobHeaders (= 0.66.3)
-    - React-Core/RCTWebSocket (= 0.66.3)
-    - React-jsi (= 0.66.3)
-    - React-RCTNetwork (= 0.66.3)
-    - ReactCommon/turbomodule/core (= 0.66.3)
-  - React-RCTImage (0.66.3):
-    - FBReactNativeSpec (= 0.66.3)
+    - React-Core/RCTBlobHeaders (= 0.66.5)
+    - React-Core/RCTWebSocket (= 0.66.5)
+    - React-jsi (= 0.66.5)
+    - React-RCTNetwork (= 0.66.5)
+    - ReactCommon/turbomodule/core (= 0.66.5)
+  - React-RCTImage (0.66.5):
+    - FBReactNativeSpec (= 0.66.5)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.3)
-    - React-Core/RCTImageHeaders (= 0.66.3)
-    - React-jsi (= 0.66.3)
-    - React-RCTNetwork (= 0.66.3)
-    - ReactCommon/turbomodule/core (= 0.66.3)
-  - React-RCTLinking (0.66.3):
-    - FBReactNativeSpec (= 0.66.3)
-    - React-Core/RCTLinkingHeaders (= 0.66.3)
-    - React-jsi (= 0.66.3)
-    - ReactCommon/turbomodule/core (= 0.66.3)
-  - React-RCTNetwork (0.66.3):
-    - FBReactNativeSpec (= 0.66.3)
+    - RCTTypeSafety (= 0.66.5)
+    - React-Core/RCTImageHeaders (= 0.66.5)
+    - React-jsi (= 0.66.5)
+    - React-RCTNetwork (= 0.66.5)
+    - ReactCommon/turbomodule/core (= 0.66.5)
+  - React-RCTLinking (0.66.5):
+    - FBReactNativeSpec (= 0.66.5)
+    - React-Core/RCTLinkingHeaders (= 0.66.5)
+    - React-jsi (= 0.66.5)
+    - ReactCommon/turbomodule/core (= 0.66.5)
+  - React-RCTNetwork (0.66.5):
+    - FBReactNativeSpec (= 0.66.5)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.3)
-    - React-Core/RCTNetworkHeaders (= 0.66.3)
-    - React-jsi (= 0.66.3)
-    - ReactCommon/turbomodule/core (= 0.66.3)
-  - React-RCTSettings (0.66.3):
-    - FBReactNativeSpec (= 0.66.3)
+    - RCTTypeSafety (= 0.66.5)
+    - React-Core/RCTNetworkHeaders (= 0.66.5)
+    - React-jsi (= 0.66.5)
+    - ReactCommon/turbomodule/core (= 0.66.5)
+  - React-RCTSettings (0.66.5):
+    - FBReactNativeSpec (= 0.66.5)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.66.3)
-    - React-Core/RCTSettingsHeaders (= 0.66.3)
-    - React-jsi (= 0.66.3)
-    - ReactCommon/turbomodule/core (= 0.66.3)
-  - React-RCTText (0.66.3):
-    - React-Core/RCTTextHeaders (= 0.66.3)
-  - React-RCTVibration (0.66.3):
-    - FBReactNativeSpec (= 0.66.3)
+    - RCTTypeSafety (= 0.66.5)
+    - React-Core/RCTSettingsHeaders (= 0.66.5)
+    - React-jsi (= 0.66.5)
+    - ReactCommon/turbomodule/core (= 0.66.5)
+  - React-RCTText (0.66.5):
+    - React-Core/RCTTextHeaders (= 0.66.5)
+  - React-RCTVibration (0.66.5):
+    - FBReactNativeSpec (= 0.66.5)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/RCTVibrationHeaders (= 0.66.3)
-    - React-jsi (= 0.66.3)
-    - ReactCommon/turbomodule/core (= 0.66.3)
-  - React-runtimeexecutor (0.66.3):
-    - React-jsi (= 0.66.3)
-  - ReactCommon/turbomodule/core (0.66.3):
+    - React-Core/RCTVibrationHeaders (= 0.66.5)
+    - React-jsi (= 0.66.5)
+    - ReactCommon/turbomodule/core (= 0.66.5)
+  - React-runtimeexecutor (0.66.5):
+    - React-jsi (= 0.66.5)
+  - ReactCommon/turbomodule/core (0.66.5):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.66.3)
-    - React-Core (= 0.66.3)
-    - React-cxxreact (= 0.66.3)
-    - React-jsi (= 0.66.3)
-    - React-logger (= 0.66.3)
-    - React-perflogger (= 0.66.3)
+    - React-callinvoker (= 0.66.5)
+    - React-Core (= 0.66.5)
+    - React-cxxreact (= 0.66.5)
+    - React-jsi (= 0.66.5)
+    - React-logger (= 0.66.5)
+    - React-perflogger (= 0.66.5)
   - RNCAsyncStorage (1.15.14):
     - React-Core
   - RNCMaskedView (0.1.11):
@@ -503,8 +503,8 @@ SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
   DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
-  FBLazyVector: de148e8310b8b878db304ceea2fec13f2c02e3a0
-  FBReactNativeSpec: 6192956c9e346013d5f1809ba049af720b11c6a4
+  FBLazyVector: a926a9aaa3596b181972abf0f47eff3dee796222
+  FBReactNativeSpec: f1141d5407f4a27c397bca5db03cc03919357b0d
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: 5337263514dd6f09803962437687240c5dc39aa4
   hermes-engine: bf7577d12ac6ccf53ab8b5af3c6ccf0dd8458c5c
@@ -512,18 +512,18 @@ SPEC CHECKSUMS:
   Permission-LocationAlways: 012fd2c1f610068c5f9a7b48bc908ea41edd0c43
   Permission-LocationWhenInUse: 13de9a01e006cb53a6ac3c9f8d1ab6cc98318d9c
   RCT-Folly: a21c126816d8025b547704b777a2ba552f3d9fa9
-  RCTRequired: 59d2b744d8c2bf2d9bc7032a9f654809adcf7d50
-  RCTTypeSafety: d0aaf7ccae5c70a4aaa3a5c3e9e0db97efae760e
-  React: fbe655dd1d12c052299b61abdc576720098d80fc
-  React-callinvoker: a535746608d9bc8b1dea7095ed4d8d3d7aae9a05
-  React-Core: 008d2638c4f80b189c8e170ff2d241027ec517fd
-  React-CoreModules: 91c9a03f4e1b74494c087d9c9a29e89a3145c228
-  React-cxxreact: 9c462fb6d59f865855e2dee2097c7d87b3d2de49
-  React-hermes: 79103a3907b81b7eeb394b37612b991076d27472
-  React-jsi: 4de8b8d70ba4ed841eb9b772bdb719f176387e21
-  React-jsiexecutor: 433a691aee158533a6a6ee9c86cb4a1684fa2853
-  React-jsinspector: d9c8eb0b53f0da206fed56612b289fec84991157
-  React-logger: e522e76fa3e9ec3e7d7115b49485cc065cf4ae06
+  RCTRequired: 405e24508a0feed1771d48caebb85c581db53122
+  RCTTypeSafety: 0654998ea6afd3dccecbf6bb379d7c10d1361a72
+  React: cce3ac45191e66a78c79234582cbfe322e4dfd00
+  React-callinvoker: 613b19264ce63cab0a2bbb6546caa24f2ad0a679
+  React-Core: fe529d7c1d74b3eb9505fdfc2f4b10f2f2984a85
+  React-CoreModules: 71f5d032922a043ab6f9023acda41371a774bf5c
+  React-cxxreact: 808c0d39b270860af712848082009d623180999c
+  React-hermes: 6d7dfec2394c40780f5db123acf7a4ae2cc01895
+  React-jsi: 01b246df3667ad921a33adeb0ce199772afe9e2b
+  React-jsiexecutor: 50a73168582868421112609d2fb155e607e34ec8
+  React-jsinspector: 953260b8580780a6e81f2a6d319a8d42fd5028d8
+  React-logger: fa4ff1e9c7e115648f7c5dafb7c20822ab4f7a7e
   react-native-config: 6502b1879f97ed5ac570a029961fc35ea606cd14
   react-native-geolocation-service: 7c9436da6dfdecd9526c62eac62ea2bc3f0cc8ea
   react-native-maps: 96b2ccec1d0c01b1c63eb2186cb668a12cf07515
@@ -531,18 +531,18 @@ SPEC CHECKSUMS:
   react-native-safe-area-context: f98b0b16d1546d208fc293b4661e3f81a895afd9
   react-native-splash-screen: 4312f786b13a81b5169ef346d76d33bc0c6dc457
   react-native-webview: e89bf2dba26a04cda967814df3ed1be99f291233
-  React-perflogger: 73732888d37d4f5065198727b167846743232882
-  React-RCTActionSheet: 96c6d774fa89b1f7c59fc460adc3245ba2d7fd79
-  React-RCTAnimation: 8940cfd3a8640bd6f6372150dbdb83a79bcbae6c
-  React-RCTBlob: e80de5fdf952a4f226a00fc54f3db526809f92f7
-  React-RCTImage: f990d6b272c7e89ff864caf0bccfb620ab3ca5d0
-  React-RCTLinking: 2280ed0d5ffb78954b484b90228d597b5f941c5f
-  React-RCTNetwork: 1359fa853c216616e711b810dcb8682a6a8e7564
-  React-RCTSettings: 84958860aaa3639f0249e751ea7702c62eb67188
-  React-RCTText: 196cf06b8cb6229d8c6dd9fc9057bdf97db5d3fb
-  React-RCTVibration: 50cfe7049167cfc7e83ac5542c6fff0c76791a9b
-  React-runtimeexecutor: bbbdb3d8fcf327c6e2249ee71b6ef1764b7dc266
-  ReactCommon: 9bac022ab71596f2b0fde1268272543184c63971
+  React-perflogger: 169fb34f60c5fd793b370002ee9c916eba9bc4ae
+  React-RCTActionSheet: 2355539e02ad5cd4b1328682ab046487e1e1e920
+  React-RCTAnimation: 150644a38c24d80f1f761859c10c727412303f57
+  React-RCTBlob: 66042a0ab4206f112ed453130f2cb8802dd7cd82
+  React-RCTImage: 3b954d8398ec4bed26cec10e10d311cb3533818b
+  React-RCTLinking: 331d9b8a0702c751c7843ddc65b64297c264adc2
+  React-RCTNetwork: 96e10dad824ce112087445199ea734b79791ad14
+  React-RCTSettings: 41feb3f5fb3319846ad0ba9e8d339e54b5774b67
+  React-RCTText: 254741e11c41516759e93ab0b8c38b90f8998f61
+  React-RCTVibration: 96dbefca7504f3e52ff47cd0ad0826d20e3a789f
+  React-runtimeexecutor: 09041c28ce04143a113eac2d357a6b06bd64b607
+  ReactCommon: 8a7a138ae43c04bb8dd760935589f326ca810484
   RNCAsyncStorage: ea6b5c280997b2b32a587793163b1f10e580c4f7
   RNCMaskedView: 0e1bc4bfa8365eba5fbbb71e07fbdc0555249489
   RNGestureHandler: e1ad51d31a580755079d5124d3ab66f0fcaa8311
@@ -551,8 +551,8 @@ SPEC CHECKSUMS:
   RNScreens: 40a2cb40a02a609938137a1e0acfbf8fc9eebf19
   RNSVG: 551acb6562324b1d52a4e0758f7ca0ec234e278f
   RNVectorIcons: 7923e585eaeb139b9f4531d25a125a1500162a0b
-  Yoga: 32a18c0e845e185f4a2a66ec76e1fd1f958f22fa
+  Yoga: b316a990bb6d115afa1b436b5626ac7c61717d17
 
 PODFILE CHECKSUM: c9aa28518810eb1b94933eb3457cc51c42bde5a7
 
-COCOAPODS: 1.11.3
+COCOAPODS: 1.12.0

--- a/src/components/weather/NextHourForecastPanel.tsx
+++ b/src/components/weather/NextHourForecastPanel.tsx
@@ -117,8 +117,7 @@ const NextHourForecastPanel: React.FC<NextHourForecastPanelProps> = ({
   );
 
   // wind direction can be with either one degree accuracy or uses cardinals (N,NE,E,...)
-  const useCardinals =
-    Config.get('weather').forecast.useCardinalsForWindDirection;
+  const useCardinals = Config.get('weather').useCardinalsForWindDirection;
   let direction = 0;
   if (useCardinals) {
     const tempDir = nextHourForecast.windDirection || 0;

--- a/src/components/weather/NextHourForecastPanel.tsx
+++ b/src/components/weather/NextHourForecastPanel.tsx
@@ -17,7 +17,7 @@ import {
 import { selectTimeZone } from '@store/location/selector';
 import { weatherSymbolGetter } from '@assets/images';
 
-import { getFeelsLikeIconName } from '@utils/helpers';
+import { getFeelsLikeIconName, getWindDirection } from '@utils/helpers';
 import { CustomTheme, GRAY_1 } from '@utils/colors';
 
 import Icon from '@components/common/Icon';
@@ -115,35 +115,6 @@ const NextHourForecastPanel: React.FC<NextHourForecastPanelProps> = ({
     precipitationUnit,
     nextHourForecast.precipitation1h
   );
-
-  // wind direction can be with either one degree accuracy or uses cardinals (N,NE,E,...)
-  const useCardinals = Config.get('weather').useCardinalsForWindDirection;
-  let direction = 0;
-  if (useCardinals) {
-    const tempDir = nextHourForecast.windDirection || 0;
-    if ((tempDir >= 338 && tempDir <= 360) || (tempDir >= 0 && tempDir <= 22)) {
-      direction = 0; // N
-    } else if (tempDir >= 23 && tempDir <= 67) {
-      direction = 45; // NE
-    } else if (tempDir >= 68 && tempDir <= 112) {
-      direction = 90; // E
-    } else if (tempDir >= 113 && tempDir <= 157) {
-      direction = 135; // SE
-    } else if (tempDir >= 158 && tempDir <= 202) {
-      direction = 180; // S
-    } else if (tempDir >= 203 && tempDir <= 247) {
-      direction = 225; // SW
-    } else if (tempDir >= 248 && tempDir <= 292) {
-      direction = 270; // W
-    } else if (tempDir >= 293 && tempDir <= 337) {
-      direction = 315; // NW
-    }
-    // for some reason icon is pointing NW instead of N => +45
-    // wind value needs 180 degree switch to show correctly where wind is coming from
-    direction = direction + 45 - 180;
-  } else {
-    direction = (nextHourForecast.windDirection || 0) + 45 - 180;
-  }
 
   return (
     <View style={styles.container}>
@@ -249,7 +220,9 @@ const NextHourForecastPanel: React.FC<NextHourForecastPanelProps> = ({
                 {
                   transform: [
                     {
-                      rotate: `${direction}deg`,
+                      rotate: `${getWindDirection(
+                        nextHourForecast.windDirection
+                      )}deg`,
                     },
                   ],
                 },

--- a/src/components/weather/NextHourForecastPanel.tsx
+++ b/src/components/weather/NextHourForecastPanel.tsx
@@ -116,6 +116,36 @@ const NextHourForecastPanel: React.FC<NextHourForecastPanelProps> = ({
     nextHourForecast.precipitation1h
   );
 
+  // wind direction can be with either one degree accuracy or uses cardinals (N,NE,E,...)
+  const useCardinals =
+    Config.get('weather').forecast.useCardinalsForWindDirection;
+  let direction = 0;
+  if (useCardinals) {
+    const tempDir = nextHourForecast.windDirection || 0;
+    if ((tempDir >= 338 && tempDir <= 360) || (tempDir >= 0 && tempDir <= 22)) {
+      direction = 0; // N
+    } else if (tempDir >= 23 && tempDir <= 67) {
+      direction = 45; // NE
+    } else if (tempDir >= 68 && tempDir <= 112) {
+      direction = 90; // E
+    } else if (tempDir >= 113 && tempDir <= 157) {
+      direction = 135; // SE
+    } else if (tempDir >= 158 && tempDir <= 202) {
+      direction = 180; // S
+    } else if (tempDir >= 203 && tempDir <= 247) {
+      direction = 225; // SW
+    } else if (tempDir >= 248 && tempDir <= 292) {
+      direction = 270; // W
+    } else if (tempDir >= 293 && tempDir <= 337) {
+      direction = 315; // NW
+    }
+    // for some reason icon is pointing NW instead of N => +45
+    // wind value needs 180 degree switch to show correctly where wind is coming from
+    direction = direction + 45 - 180;
+  } else {
+    direction = (nextHourForecast.windDirection || 0) + 45 - 180;
+  }
+
   return (
     <View style={styles.container}>
       <View style={styles.alignCenter} accessible accessibilityRole="header">
@@ -220,9 +250,7 @@ const NextHourForecastPanel: React.FC<NextHourForecastPanelProps> = ({
                 {
                   transform: [
                     {
-                      rotate: `${
-                        (nextHourForecast.windDirection || 0) + 45 - 180
-                      }deg`,
+                      rotate: `${direction}deg`,
                     },
                   ],
                 },

--- a/src/components/weather/forecast/ForecastListColumn.tsx
+++ b/src/components/weather/forecast/ForecastListColumn.tsx
@@ -12,7 +12,7 @@ import { weatherSymbolGetter } from '@assets/images';
 import { CustomTheme } from '@utils/colors';
 import * as constants from '@store/forecast/constants';
 
-import { isOdd } from '@utils/helpers';
+import { isOdd, getWindDirection } from '@utils/helpers';
 import { Config } from '@config';
 import {
   converter,
@@ -108,39 +108,6 @@ const ForecastListColumn: React.FC<ForecastListColumnProps> = ({
               )}`
             );
 
-            // wind direction can be with either one degree accuracy or uses cardinals (N,NE,E,...)
-            const useCardinals =
-              Config.get('weather').useCardinalsForWindDirection;
-            let direction = 0;
-            if (useCardinals) {
-              const tempDir = data.windDirection || 0;
-              if (
-                (tempDir >= 338 && tempDir <= 360) ||
-                (tempDir >= 0 && tempDir <= 22)
-              ) {
-                direction = 0; // N
-              } else if (tempDir >= 23 && tempDir <= 67) {
-                direction = 45; // NE
-              } else if (tempDir >= 68 && tempDir <= 112) {
-                direction = 90; // E
-              } else if (tempDir >= 113 && tempDir <= 157) {
-                direction = 135; // SE
-              } else if (tempDir >= 158 && tempDir <= 202) {
-                direction = 180; // S
-              } else if (tempDir >= 203 && tempDir <= 247) {
-                direction = 225; // SW
-              } else if (tempDir >= 248 && tempDir <= 292) {
-                direction = 270; // W
-              } else if (tempDir >= 293 && tempDir <= 337) {
-                direction = 315; // NW
-              }
-              // for some reason icon is pointing NW instead of N => +45
-              // wind value needs 180 degree switch to show correctly where wind is coming from
-              direction = direction + 45 - 180;
-            } else {
-              direction = (data.windDirection || 0) + 45 - 180;
-            }
-
             return (
               <View
                 accessibilityLabel={
@@ -166,7 +133,7 @@ const ForecastListColumn: React.FC<ForecastListColumnProps> = ({
                     style={{
                       transform: [
                         {
-                          rotate: `${direction}deg`,
+                          rotate: `${getWindDirection(data.windDirection)}deg`,
                         },
                       ],
                     }}

--- a/src/components/weather/forecast/ForecastListColumn.tsx
+++ b/src/components/weather/forecast/ForecastListColumn.tsx
@@ -110,7 +110,7 @@ const ForecastListColumn: React.FC<ForecastListColumnProps> = ({
 
             // wind direction can be with either one degree accuracy or uses cardinals (N,NE,E,...)
             const useCardinals =
-              Config.get('weather').forecast.useCardinalsForWindDirection;
+              Config.get('weather').useCardinalsForWindDirection;
             let direction = 0;
             if (useCardinals) {
               const tempDir = data.windDirection || 0;

--- a/src/components/weather/forecast/ForecastListColumn.tsx
+++ b/src/components/weather/forecast/ForecastListColumn.tsx
@@ -107,6 +107,40 @@ const ForecastListColumn: React.FC<ForecastListColumnProps> = ({
                 windSpeedUnit
               )}`
             );
+
+            // wind direction can be with either one degree accuracy or uses cardinals (N,NE,E,...)
+            const useCardinals =
+              Config.get('weather').forecast.useCardinalsForWindDirection;
+            let direction = 0;
+            if (useCardinals) {
+              const tempDir = data.windDirection || 0;
+              if (
+                (tempDir >= 338 && tempDir <= 360) ||
+                (tempDir >= 0 && tempDir <= 22)
+              ) {
+                direction = 0; // N
+              } else if (tempDir >= 23 && tempDir <= 67) {
+                direction = 45; // NE
+              } else if (tempDir >= 68 && tempDir <= 112) {
+                direction = 90; // E
+              } else if (tempDir >= 113 && tempDir <= 157) {
+                direction = 135; // SE
+              } else if (tempDir >= 158 && tempDir <= 202) {
+                direction = 180; // S
+              } else if (tempDir >= 203 && tempDir <= 247) {
+                direction = 225; // SW
+              } else if (tempDir >= 248 && tempDir <= 292) {
+                direction = 270; // W
+              } else if (tempDir >= 293 && tempDir <= 337) {
+                direction = 315; // NW
+              }
+              // for some reason icon is pointing NW instead of N => +45
+              // wind value needs 180 degree switch to show correctly where wind is coming from
+              direction = direction + 45 - 180;
+            } else {
+              direction = (data.windDirection || 0) + 45 - 180;
+            }
+
             return (
               <View
                 accessibilityLabel={
@@ -132,7 +166,7 @@ const ForecastListColumn: React.FC<ForecastListColumnProps> = ({
                     style={{
                       transform: [
                         {
-                          rotate: `${(data.windDirection || 0) + 45 - 180}deg`,
+                          rotate: `${direction}deg`,
                         },
                       ],
                     }}

--- a/src/components/weather/observation/List.tsx
+++ b/src/components/weather/observation/List.tsx
@@ -112,8 +112,7 @@ const List: React.FC<ListProps> = ({ clockType, data, parameter }) => {
       );
 
       // wind direction can be with either one degree accuracy or uses cardinals (N,NE,E,...)
-      const useCardinals =
-        Config.get('weather').forecast.useCardinalsForWindDirection;
+      const useCardinals = Config.get('weather').useCardinalsForWindDirection;
       let direction = 0;
       if (useCardinals) {
         const tempDir = timeStep.windDirection || 0;

--- a/src/components/weather/observation/List.tsx
+++ b/src/components/weather/observation/List.tsx
@@ -9,7 +9,11 @@ import Icon from '@components/common/Icon';
 import { ObservationParameters, TimeStepData } from '@store/observation/types';
 import { GRAY_1_OPACITY, CustomTheme } from '@utils/colors';
 import { capitalize } from '@utils/chart';
-import { getObservationCellValue, getParameterUnit } from '@utils/helpers';
+import {
+  getObservationCellValue,
+  getParameterUnit,
+  getWindDirection,
+} from '@utils/helpers';
 import { Config } from '@config';
 import { ClockType } from '@store/settings/types';
 import { getForecastParameterUnitTranslationKey } from '@utils/units';
@@ -111,38 +115,6 @@ const List: React.FC<ListProps> = ({ clockType, data, parameter }) => {
         false
       );
 
-      // wind direction can be with either one degree accuracy or uses cardinals (N,NE,E,...)
-      const useCardinals = Config.get('weather').useCardinalsForWindDirection;
-      let direction = 0;
-      if (useCardinals) {
-        const tempDir = timeStep.windDirection || 0;
-        if (
-          (tempDir >= 338 && tempDir <= 360) ||
-          (tempDir >= 0 && tempDir <= 22)
-        ) {
-          direction = 0; // N
-        } else if (tempDir >= 23 && tempDir <= 67) {
-          direction = 45; // NE
-        } else if (tempDir >= 68 && tempDir <= 112) {
-          direction = 90; // E
-        } else if (tempDir >= 113 && tempDir <= 157) {
-          direction = 135; // SE
-        } else if (tempDir >= 158 && tempDir <= 202) {
-          direction = 180; // S
-        } else if (tempDir >= 203 && tempDir <= 247) {
-          direction = 225; // SW
-        } else if (tempDir >= 248 && tempDir <= 292) {
-          direction = 270; // W
-        } else if (tempDir >= 293 && tempDir <= 337) {
-          direction = 315; // NW
-        }
-        // for some reason icon is pointing NW instead of N => +45
-        // wind value needs 180 degree switch to show correctly where wind is coming from
-        direction = direction + 45 - 180;
-      } else {
-        direction = (timeStep.windDirection || 0) + 45 - 180;
-      }
-
       return (
         <View style={styles.row}>
           <View style={[styles.windColumn]}>
@@ -182,9 +154,9 @@ const List: React.FC<ListProps> = ({ clockType, data, parameter }) => {
                   accessibilityLabel={
                     timeStep.windCompass8
                       ? `${t(`windDirection.${timeStep.windCompass8}`)}.`
-                      : `${t('measurements.windDirection')} ${direction} ${t(
-                          'paramUnits.°'
-                        )}.`
+                      : `${t('measurements.windDirection')} ${getWindDirection(
+                          timeStep.windDirection
+                        )} ${t('paramUnits.°')}.`
                   }
                   name="wind-arrow"
                   style={[
@@ -193,7 +165,9 @@ const List: React.FC<ListProps> = ({ clockType, data, parameter }) => {
                       color: colors.hourListText,
                       transform: [
                         {
-                          rotate: `${direction}deg`,
+                          rotate: `${getWindDirection(
+                            timeStep.windDirection
+                          )}deg`,
                         },
                       ],
                     },

--- a/src/components/weather/observation/List.tsx
+++ b/src/components/weather/observation/List.tsx
@@ -111,6 +111,39 @@ const List: React.FC<ListProps> = ({ clockType, data, parameter }) => {
         false
       );
 
+      // wind direction can be with either one degree accuracy or uses cardinals (N,NE,E,...)
+      const useCardinals =
+        Config.get('weather').forecast.useCardinalsForWindDirection;
+      let direction = 0;
+      if (useCardinals) {
+        const tempDir = timeStep.windDirection || 0;
+        if (
+          (tempDir >= 338 && tempDir <= 360) ||
+          (tempDir >= 0 && tempDir <= 22)
+        ) {
+          direction = 0; // N
+        } else if (tempDir >= 23 && tempDir <= 67) {
+          direction = 45; // NE
+        } else if (tempDir >= 68 && tempDir <= 112) {
+          direction = 90; // E
+        } else if (tempDir >= 113 && tempDir <= 157) {
+          direction = 135; // SE
+        } else if (tempDir >= 158 && tempDir <= 202) {
+          direction = 180; // S
+        } else if (tempDir >= 203 && tempDir <= 247) {
+          direction = 225; // SW
+        } else if (tempDir >= 248 && tempDir <= 292) {
+          direction = 270; // W
+        } else if (tempDir >= 293 && tempDir <= 337) {
+          direction = 315; // NW
+        }
+        // for some reason icon is pointing NW instead of N => +45
+        // wind value needs 180 degree switch to show correctly where wind is coming from
+        direction = direction + 45 - 180;
+      } else {
+        direction = (timeStep.windDirection || 0) + 45 - 180;
+      }
+
       return (
         <View style={styles.row}>
           <View style={[styles.windColumn]}>
@@ -150,9 +183,9 @@ const List: React.FC<ListProps> = ({ clockType, data, parameter }) => {
                   accessibilityLabel={
                     timeStep.windCompass8
                       ? `${t(`windDirection.${timeStep.windCompass8}`)}.`
-                      : `${t('measurements.windDirection')} ${
-                          timeStep.windDirection
-                        } ${t('paramUnits.°')}.`
+                      : `${t('measurements.windDirection')} ${direction} ${t(
+                          'paramUnits.°'
+                        )}.`
                   }
                   name="wind-arrow"
                   style={[
@@ -161,7 +194,7 @@ const List: React.FC<ListProps> = ({ clockType, data, parameter }) => {
                       color: colors.hourListText,
                       transform: [
                         {
-                          rotate: `${timeStep.windDirection + 45 - 180}deg`,
+                          rotate: `${direction}deg`,
                         },
                       ],
                     },

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -182,7 +182,6 @@ export interface ConfigType {
         producer?: string;
         parameters: (keyof ForecastParameters)[];
       }[];
-      useCardinalsForWindDirection?: boolean;
       defaultParameters: DisplayParameters[];
       excludeDayLength?: boolean;
       infoBottomSheet?: {
@@ -190,6 +189,7 @@ export interface ConfigType {
       };
     };
     observation: ObservationEnabled | ObservationDisabled;
+    useCardinalsForWindDirection?: boolean;
   };
   warnings: WarningsEnabled | WarningsDisabled;
   settings: {

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -182,6 +182,7 @@ export interface ConfigType {
         producer?: string;
         parameters: (keyof ForecastParameters)[];
       }[];
+      useCardinalsForWindDirection?: boolean;
       defaultParameters: DisplayParameters[];
       excludeDayLength?: boolean;
       infoBottomSheet?: {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -118,7 +118,7 @@ export const getPrecipitationLevel = (amount: number): keyof Rain => {
   return 0;
 };
 
-export const getWindDirection = (dataValue: number): number => {
+export const getWindDirection = (dataValue): number => {
   const useCardinals = Config.get('weather').useCardinalsForWindDirection;
   let direction = 0;
   if (useCardinals) {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -118,6 +118,37 @@ export const getPrecipitationLevel = (amount: number): keyof Rain => {
   return 0;
 };
 
+export const getWindDirection = (dataValue: number): number => {
+  const useCardinals = Config.get('weather').useCardinalsForWindDirection;
+  let direction = 0;
+  if (useCardinals) {
+    const tempDir = dataValue || 0;
+    if ((tempDir >= 338 && tempDir <= 360) || (tempDir >= 0 && tempDir <= 22)) {
+      direction = 0; // N
+    } else if (tempDir >= 23 && tempDir <= 67) {
+      direction = 45; // NE
+    } else if (tempDir >= 68 && tempDir <= 112) {
+      direction = 90; // E
+    } else if (tempDir >= 113 && tempDir <= 157) {
+      direction = 135; // SE
+    } else if (tempDir >= 158 && tempDir <= 202) {
+      direction = 180; // S
+    } else if (tempDir >= 203 && tempDir <= 247) {
+      direction = 225; // SW
+    } else if (tempDir >= 248 && tempDir <= 292) {
+      direction = 270; // W
+    } else if (tempDir >= 293 && tempDir <= 337) {
+      direction = 315; // NW
+    }
+    // for some reason icon is pointing NW instead of N => +45
+    // wind value needs 180 degree switch to show correctly where wind is coming from
+    direction = direction + 45 - 180;
+  } else {
+    direction = (dataValue || 0) + 45 - 180;
+  }
+  return direction;
+};
+
 type DotOrComma = ',' | '.';
 
 export const toStringWithDecimal = (

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -118,7 +118,7 @@ export const getPrecipitationLevel = (amount: number): keyof Rain => {
   return 0;
 };
 
-export const getWindDirection = (dataValue: number): number => {
+export const getWindDirection = (dataValue: number | undefined): number => {
   const useCardinals = Config.get('weather').useCardinalsForWindDirection;
   let direction = 0;
   if (useCardinals) {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -118,7 +118,7 @@ export const getPrecipitationLevel = (amount: number): keyof Rain => {
   return 0;
 };
 
-export const getWindDirection = (dataValue): number => {
+export const getWindDirection = (dataValue: number): number => {
   const useCardinals = Config.get('weather').useCardinalsForWindDirection;
   let direction = 0;
   if (useCardinals) {


### PR DESCRIPTION
Added cardinal support (direction is rounded to N, NE, E, ... directions) to settings. Works in following UI elements:
- next hour's forecast -panel
- hourly forecast table
- observation's wind -list -tab's table

defaultConfig.ts can have weather.useCardinalsForWindDirection -setting. Using degrees by default.