### PR TITLE
Fix layout issue in map time slider when 12-hour clock is in use

### DIFF
--- a/src/components/map/ui/SliderStep.tsx
+++ b/src/components/map/ui/SliderStep.tsx
@@ -78,7 +78,6 @@ const SliderStep: React.FC<SliderStepProps> = ({
           style={[
             styles.text,
             styles.textBlock,
-            clockType === 12 && styles.twelveHourClockTextBlock,
             {
               color: colors.hourListText,
             },
@@ -116,9 +115,6 @@ const styles = StyleSheet.create({
     marginRight: '25%',
     marginLeft: '-75%',
     textAlign: 'center',
-  },
-  twelveHourClockTextBlock: {
-    width: '350%', // make 12-hour clock time fully visible on the screen
   },
   lastQuarterContainer: {
     height: 32,

--- a/src/components/map/ui/TimeSlider.tsx
+++ b/src/components/map/ui/TimeSlider.tsx
@@ -129,7 +129,8 @@ const TimeSlider: React.FC<TimeSliderProps> = ({
   }, [activeOverlayId, overlay]);
 
   const stepWidth =
-    (sliderStep >= STEP_60 ? 4 : 1) * multiplier * QUARTER_WIDTH;
+    (sliderStep >= STEP_60 ? 4 : 1) * multiplier * QUARTER_WIDTH +
+    (clockType === 12 ? 20 : 0);
 
   const isFocused = useIsFocused();
 


### PR DESCRIPTION
Resolves issue 484.

Widens the steps in `TimeSlider` so that the time steps fit in the layout also in 12-hour format.