### PR TITLE
issue-494 Changed allow location sharing accept-button's text to Next…

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -540,7 +540,7 @@
     "accept": "Accept",
     "location": "Location",
     "locationDescription": "The app uses the device location to locate the user. The location is used only for visual display purposes. ",
-    "acceptLocation": "Allow location",
+    "acceptLocation": "Next",
     "declineLocation": "Do not allow"
   },
   "onboarding": {

--- a/i18n/fi.json
+++ b/i18n/fi.json
@@ -540,7 +540,7 @@
     "accept": "Hyväksy",
     "location": "Sijainti",
     "locationDescription": "Sovellus käyttää laitteen sijaintia paikantamaan käyttäjän. Sijaintia käytetään vain esitystarkoitukseen.",
-    "acceptLocation": "Salli sijainti",
+    "acceptLocation": "Seuraava",
     "declineLocation": "Älä salli"
   },
   "onboarding": {

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -540,7 +540,7 @@
     "accept": "Godkänn",
     "location": "Läge",
     "locationDescription": "Applikationen använder enhetens position för att lokalisera användaren. Positionen används endast för presentationssyfte.",
-    "acceptLocation": "Tillåt position",
+    "acceptLocation": "Nästa",
     "declineLocation": "Tillåt inte"
   },
   "onboarding": {


### PR DESCRIPTION
… (this was an issue for IOS reviewers in Jamaican version). Accept -button doesn't do the acception, it's done in the opening native window. Denying is fine, it can be done from Do not allow -button.

resolves #494 