### PR TITLE
issue-534: increased axiosClient default timeout

### DIFF
--- a/src/utils/axiosClient.ts
+++ b/src/utils/axiosClient.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosRequestConfig } from 'axios';
 
 const axiosClient = async (options: AxiosRequestConfig) => {
-  const { timeout = 10000 } = options;
+  const { timeout = 20000 } = options;
   const source = axios.CancelToken.source();
 
   const requestConfig = {


### PR DESCRIPTION
Tested the app with simulated 2G connection speeds. 10s timeout was too short to load forecasts and observations, 20s timeout seems to work much better.

Other idea was to add retries if API queries fail, but didn't implement that yet, because it might cause too many connections to pile up on server if we run 20s + 20s queries for large number of users. At least it would need some discussions with server people.

Also didn't add timeout to configuration, because that caused cyclic dependency with imports and probably there is no need to change default timeout.