### PR TITLE
issue-554: fix incorrect comparison of observation values

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -220,7 +220,7 @@ export const getObservationCellValue = (
           decimals
         )
       : dividedValue;
-    if (!value) return '-';
+    if (value === null) return '-';
 
     return `${(unitParameterObject
       ? value


### PR DESCRIPTION
Incorrect comparison caused that total cloud cover observation with value 0 was never displayed.