### PR TITLE
issue-582: Use axios-cache-interceptor to cache timeseries queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@react-navigation/stack": "^6.2.1",
     "@types/supercluster": "^5.0.3",
     "axios": "^1.6.8",
+    "axios-cache-interceptor": "^1.5.3",
     "fast-xml-parser": "^3.21.1",
     "geolib": "^3.3.3",
     "i18next": "^23.10.1",

--- a/src/network/WeatherApi.ts
+++ b/src/network/WeatherApi.ts
@@ -30,7 +30,6 @@ export const getForecast = async (
 
   const params = {
     ...location,
-    starttime: Math.floor(Date.now() / 60 / 1000) * 60,
     endtime: timePeriod,
     format: 'json',
     attributes: 'geoid',

--- a/src/utils/axiosClient.ts
+++ b/src/utils/axiosClient.ts
@@ -1,12 +1,19 @@
-import axios, { AxiosRequestConfig } from 'axios';
+import Axios, { AxiosRequestConfig } from 'axios';
+import { setupCache } from 'axios-cache-interceptor';
 
-const axiosClient = async (options: AxiosRequestConfig) => {
+const instance = Axios.create();
+const axios = setupCache(instance);
+
+const axiosClient = async (
+  options: AxiosRequestConfig,
+  abortController?: AbortController
+) => {
   const { timeout = 20000 } = options;
-  const source = axios.CancelToken.source();
+  const controller = abortController || new AbortController();
 
   const requestConfig = {
     ...options,
-    cancelToken: options.cancelToken || source.token,
+    signal: controller.signal,
   };
   delete requestConfig.timeout;
 
@@ -24,7 +31,7 @@ const axiosClient = async (options: AxiosRequestConfig) => {
     });
 
   timeoutId = setTimeout(
-    () => source.cancel(`Timeout of ${timeout}ms exceeded`),
+    () => controller.abort(`Timeout of ${timeout}ms exceeded`),
     timeout
   );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3265,6 +3265,15 @@ axe-core@=4.7.0:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.7.0.tgz#34ba5a48a8b564f67e103f0aa5768d76e15bbbbf"
   integrity sha512-M0JtH+hlOL5pLQwHOLNYZaXuhqmvS8oExsqB1SBYgA4Dk7u/xx+YdGHXaK5pyUfed5mYXdlYiphWq3G8cRi5JQ==
 
+axios-cache-interceptor@^1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/axios-cache-interceptor/-/axios-cache-interceptor-1.5.3.tgz#2083fc68aacb915240e37edcb792b4fed63540be"
+  integrity sha512-kPgGId9XW7tR+VF7hgSkqF4f6FrV4ecCyKxjkD9v1hNJ4sXSAskocr7SMKaVHVvrbzVeruwB6yL6Y9/lY1ApKg==
+  dependencies:
+    cache-parser "1.2.5"
+    fast-defer "1.1.8"
+    object-code "1.3.3"
+
 axios@^1.6.8:
   version "1.6.8"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.8.tgz#66d294951f5d988a00e87a0ffb955316a619ea66"
@@ -3576,6 +3585,11 @@ bytes@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.0.0.tgz#d32815404d689699f85a4ea4fa8755dd13a96048"
   integrity sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=
+
+cache-parser@1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/cache-parser/-/cache-parser-1.2.5.tgz#f19102a788b03055389730eb0493e463e1b379ac"
+  integrity sha512-Md/4VhAHByQ9frQ15WD6LrMNiVw9AEl/J7vWIXw+sxT6fSOpbtt6LHTp76vy8+bOESPBO94117Hm2bIjlI7XjA==
 
 call-bind@^1.0.0, call-bind@^1.0.2:
   version "1.0.2"
@@ -4993,6 +5007,11 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-defer@1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/fast-defer/-/fast-defer-1.1.8.tgz#940ef9597b2ea51c4cd08e99d0f2a8978fa49ba2"
+  integrity sha512-lEJeOH5VL5R09j6AA0D4Uvq7AgsHw0dAImQQ+F3iSyHZuAxyQfWobsagGpTcOPvJr3urmKRHrs+Gs9hV+/Qm/Q==
 
 fast-diff@^1.1.2:
   version "1.2.0"
@@ -7337,6 +7356,11 @@ object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
+
+object-code@1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/object-code/-/object-code-1.3.3.tgz#cf21843ddfecce3ec73fd141f66a7f16ba0cb93e"
+  integrity sha512-/Ds4Xd5xzrtUOJ+xJQ57iAy0BZsZltOHssnDgcZ8DOhgh41q1YJCnTPnWdWSLkNGNnxYzhYChjc5dgC9mEERCA==
 
 object-inspect@^1.11.0, object-inspect@^1.11.1, object-inspect@^1.9.0:
   version "1.12.0"


### PR DESCRIPTION
The library didn't work well with axios CancelToken, so had to convert CancelToken usage to AbortController. CancelToken is deprecated anyway, so the change is better for the future anyway.

Also starttime was removed from forecast queries to keep querystring same and cacheable.