### PR TITLE
issue-588: Fix for irregular order in observation list

### DIFF
--- a/src/store/observation/reducer.ts
+++ b/src/store/observation/reducer.ts
@@ -43,7 +43,7 @@ const formatData = (
                 distance: Number(distance),
                 type: stationType,
               });
-              data[Number(id)] = dataHolder.reverse();
+              data[Number(id)] = [...dataHolder].reverse();
             }
           );
         }


### PR DESCRIPTION
Typical javascript issue that the same array was mutated multiple times and that caused irregular order for observations. The root cause was that axios-cache-interceptor was added previously and the library returns same object from memory cache if it exists. The data returned by axios-cache-interceptor was mutated in formatData-method, often multiple times.

Also tried to fix issue by adding `cloneData` option for axios-cache-interceptor, but that didn't work

https://axios-cache-interceptor.js.org/guide/storages