### PR TITLE
issue-605: Restored code that was lost in java -> kotlin conversion

### DIFF
--- a/android/app/src/main/java/fi/fmi/mobileweather/MainActivity.kt
+++ b/android/app/src/main/java/fi/fmi/mobileweather/MainActivity.kt
@@ -1,11 +1,18 @@
 package fi.fmi.mobileweather
 
+import android.os.Bundle;
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
 import com.facebook.react.defaults.DefaultReactActivityDelegate
+import org.devio.rn.splashscreen.SplashScreen;
 
 class MainActivity : ReactActivity() {
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    SplashScreen.show(this);
+    super.onCreate(null); // for react-native-screens
+  }
 
   /**
    * Returns the name of the main component registered from JavaScript. This is used to schedule


### PR DESCRIPTION
Some code was lost in Kotlin conversion that caused splash screen not showing and occasional crashes in some devices/Android versions.