### PR TITLE
issue-608: Removed javascript-code that caused injectScript error in iOS 18

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -951,7 +951,7 @@ PODS:
     - React-Core
   - react-native-splash-screen (3.3.0):
     - React-Core
-  - react-native-webview (13.10.5):
+  - react-native-webview (13.12.2):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1518,7 +1518,7 @@ SPEC CHECKSUMS:
   react-native-netinfo: 076df4f9b07f6670acf4ce9a75aac8d34c2e2ccc
   react-native-safe-area-context: b7daa1a8df36095a032dff095a1ea8963cb48371
   react-native-splash-screen: 4312f786b13a81b5169ef346d76d33bc0c6dc457
-  react-native-webview: 553abd09f58e340fdc7746c9e2ae096839e99911
+  react-native-webview: 8d746f921964c87b87b190bf6a46fa148d40cd0f
   React-nativeconfig: fa5de9d8f4dbd5917358f8ad3ad1e08762f01dcb
   React-NativeModulesApple: 585d1b78e0597de364d259cb56007052d0bda5e5
   React-perflogger: 7bb9ba49435ff66b666e7966ee10082508a203e8

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "react-native-svg": "^15.4.0",
     "react-native-svg-transformer": "^1.3.0",
     "react-native-vector-icons": "9.2.0",
-    "react-native-webview": "^13.8.1",
+    "react-native-webview": "^13.12.2",
     "react-redux": "^8",
     "redux": "^4.1.2",
     "redux-persist": "^6.0.0",

--- a/src/components/warnings/WarningsWebViewPanel.tsx
+++ b/src/components/warnings/WarningsWebViewPanel.tsx
@@ -1,40 +1,22 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { WebView } from 'react-native-webview';
-import { useIsFocused, useTheme } from '@react-navigation/native';
+import { useTheme } from '@react-navigation/native';
 import { Config } from '@config';
-import { useReloader } from '@utils/reloader';
 import PanelHeader from '@components/weather/common/PanelHeader';
 import { CustomTheme } from '@utils/colors';
 
 const WarningsWebViewPanel: React.FC = () => {
-  const { shouldReload } = useReloader();
-  const [updated, setUpdated] = useState<number>(Date.now());
   const [viewHeight, setViewHeight] = useState<number>(2000);
   const { dark } = useTheme() as CustomTheme;
   const webViewRef = useRef(null);
-  const isFocused = useIsFocused();
   const { i18n, t } = useTranslation('warnings');
   const locale = ['en', 'fi', 'sv'].includes(i18n.language)
     ? i18n.language
     : 'en';
 
-  const { webViewUrl, updateInterval } = Config.get('warnings');
-
-  useEffect(() => {
-    const now = Date.now();
-    const timeToUpdate = updated + (updateInterval ?? 5) * 60 * 1000;
-    if (isFocused && (now > timeToUpdate || shouldReload > timeToUpdate)) {
-      const script = `
-      document.getElementById('fmi-warnings').__vue__.update();
-      true;
-      `;
-      // @ts-ignore
-      webViewRef?.current?.injectJavaScript(script);
-      setUpdated(now);
-    }
-  }, [isFocused, updated, shouldReload, updateInterval]);
+  const { webViewUrl } = Config.get('warnings');
 
   if (!webViewUrl) {
     return null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4035,15 +4035,15 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==
 
-escape-string-regexp@2.0.0, escape-string-regexp@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
-  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
-
 escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==
+
+escape-string-regexp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
+  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
 escape-string-regexp@^4.0.0:
   version "4.0.0"
@@ -7134,12 +7134,12 @@ react-native-vector-icons@9.2.0:
     prop-types "^15.7.2"
     yargs "^16.1.1"
 
-react-native-webview@^13.8.1:
-  version "13.10.5"
-  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-13.10.5.tgz#d6d2238b12dd295765eb5d4fdbb34759ffd1df27"
-  integrity sha512-ZfQJHyifuZop8cQB8HYpL9dxss9Cw9sOlMU+/yarfG/ugoL0rky/0tq9QmEydFMXjDSplSUb22OrRdFlqfXe0g==
+react-native-webview@^13.12.2:
+  version "13.12.2"
+  resolved "https://registry.yarnpkg.com/react-native-webview/-/react-native-webview-13.12.2.tgz#b379b28c725632efabb42a2cf8387bd03cf34f33"
+  integrity sha512-OpRcEhf1IEushREax6rrKTeqGrHZ9OmryhZLBLQQU4PwjqVsq55iC8OdYSD61/F628f9rURn9THyxEZjrknpQQ==
   dependencies:
-    escape-string-regexp "2.0.0"
+    escape-string-regexp "^4.0.0"
     invariant "2.2.4"
 
 react-native@0.74.3:


### PR DESCRIPTION
JS-code

```
document.getElementById('fmi-warnings').__vue__.update();
```

doesn't work with current Smartmet Alert client. Android webview and earlier iOS versions silently ignored javascript error, but in iOS18 this caused injectScript-error.

Smartmet Alert client updates warnings when warning view tab is activated or when app comes active from background state, so it should update often enough so that same warnings are displayed in `WarningsPanel` and on the map.

Also updated react-native-webview to latest version, because there seemed to be some iOS fixes.