### PR TITLE
issue-601: Use 15:00 local time for daily weather symbol if available

### DIFF
--- a/src/store/forecast/selectors.ts
+++ b/src/store/forecast/selectors.ts
@@ -84,7 +84,7 @@ export const selectHeaderLevelForecast = createSelector(
   selectForecastByDay,
   (forecastByDay) =>
     forecastByDay &&
-    Object.keys(forecastByDay).map((key: string, dayIndex: number) => {
+    Object.keys(forecastByDay).map((key: string) => {
       const dayArr = forecastByDay[key];
       const tempArray = dayArr.map((h) => h.temperature || 0);
       // get forecasted min and max temps for current day
@@ -97,7 +97,7 @@ export const selectHeaderLevelForecast = createSelector(
 
       const roundedTotalPrecipitation =
         Math.round((sumPrecipitation + Number.EPSILON) * 100) / 100;
-      const index = getIndexForDaySmartSymbol(dayArr, dayIndex);
+      const index = getIndexForDaySmartSymbol(dayArr);
 
       const { smartSymbol } = dayArr[index];
       const timeStamp = dayArr[0].epochtime;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -341,29 +341,16 @@ export const getFeelsLikeIconName = (
 export const isOdd = (num: number) => !!(num % 2);
 
 /** Returns the index of 15:00 or nearest */
-export const getIndexForDaySmartSymbol = (
-  dayArray: TimeStepData[],
-  dayIndex: number
-): number => {
+export const getIndexForDaySmartSymbol = (dayArray: TimeStepData[]): number => {
   if (dayArray.length === 24) {
-    return 14; // choose 14:00 (2.00 PM) local time as the default time
+    return 15; // choose 15:00 (3.00 PM) local time as the default time
   }
-  if (dayArray.length >= 10) {
-    return 14 - (24 - dayArray.length); // choose index of 14:00 if available from a list with fewer than 24 hourly forecasts
+  if (dayArray.length >= 9) {
+    return 15 - (24 - dayArray.length); // choose index of 15:00 if available from a list with fewer than 24 hourly forecasts
   }
-  const index = dayArray.findIndex((d) => {
-    const dateObj = new Date(d.epochtime * 1000);
-    const hours = dateObj.getHours();
-    return hours === 14;
-  });
 
-  if (dayIndex === 0 && index < 0) {
-    return 0;
-  }
-  if (index < 0) {
-    return dayArray.length - 1;
-  }
-  return index;
+  // Return first timestamp of day if no 15:00 available (current local time > 15:00)
+  return 0;
 };
 
 const severities: Severity[] = ['Moderate', 'Severe', 'Extreme'];


### PR DESCRIPTION
14:00 local time was used before the change. There was also other issue

The code

```
  const index = dayArray.findIndex((d) => {
    const dateObj = new Date(d.epochtime * 1000);
    const hours = dateObj.getHours();
    return hours === 14;
  });
```

used device local time and didn't work for foreign locations. Removed code, because it returned random indexes for foreign locations. The zero index is returned instead, because it is closest to 15:00 if that time is passed already.