### PR TITLE
issue-612: Update data by interval

### DIFF
--- a/src/components/warnings/WarningsWebViewPanel.tsx
+++ b/src/components/warnings/WarningsWebViewPanel.tsx
@@ -7,7 +7,13 @@ import { Config } from '@config';
 import PanelHeader from '@components/weather/common/PanelHeader';
 import { CustomTheme } from '@utils/colors';
 
-const WarningsWebViewPanel: React.FC = () => {
+type WarningsWebViewPanelProps = {
+  updateInterval: number;
+};
+
+const WarningsWebViewPanel: React.FC<WarningsWebViewPanelProps> = (
+  updateInterval
+) => {
   const [viewHeight, setViewHeight] = useState<number>(2000);
   const { dark } = useTheme() as CustomTheme;
   const webViewRef = useRef(null);
@@ -36,7 +42,7 @@ const WarningsWebViewPanel: React.FC = () => {
       <smartmet-alert-client language="${locale}" theme="${
     dark ? 'dark' : 'light'
   }" gray-scale-selector="true"></smartmet-alert-client>
-      <script type="module" src="${webViewUrl}/index.js"></script>
+      <script type="module" src="${webViewUrl}/index.js" refresh-interval="${updateInterval}"></script>
       <script>
         const resizeObserver = new ResizeObserver(entries => window.ReactNativeWebView.postMessage(entries[0].target.clientHeight));
         resizeObserver.observe(document.body);

--- a/src/components/weather/ForecastPanel.tsx
+++ b/src/components/weather/ForecastPanel.tsx
@@ -59,7 +59,9 @@ const connector = connect(mapStateToProps, mapDispatchToProps);
 
 type PropsFromRedux = ConnectedProps<typeof connector>;
 
-type ForecastPanelProps = PropsFromRedux;
+type ForecastPanelProps = PropsFromRedux & {
+  currentHour: number;
+};
 
 const ForecastPanel: React.FC<ForecastPanelProps> = ({
   clockType,
@@ -72,6 +74,7 @@ const ForecastPanel: React.FC<ForecastPanelProps> = ({
   timezone,
   displayFormat,
   updateDisplayFormat,
+  currentHour, // just for re-rendering every hour
 }) => {
   const { colors } = useTheme() as CustomTheme;
   const { t, i18n } = useTranslation('forecast');
@@ -268,6 +271,7 @@ const ForecastPanel: React.FC<ForecastPanelProps> = ({
             activeDayIndex={activeDayIndex}
             setActiveDayIndex={(i) => setActiveDayIndex(i)}
             currentDayOffset={sections[0].data.length}
+            currentHour={currentHour}
           />
         )}
         {sections &&

--- a/src/components/weather/NextHourForecastPanel.tsx
+++ b/src/components/weather/NextHourForecastPanel.tsx
@@ -42,7 +42,9 @@ const connector = connect(mapStateToProps, {});
 
 type PropsFromRedux = ConnectedProps<typeof connector>;
 
-type NextHourForecastPanelProps = PropsFromRedux;
+type NextHourForecastPanelProps = PropsFromRedux & {
+  currentHour: number;
+};
 
 const NextHourForecastPanel: React.FC<NextHourForecastPanelProps> = ({
   clockType,
@@ -50,6 +52,8 @@ const NextHourForecastPanel: React.FC<NextHourForecastPanelProps> = ({
   nextHourForecast,
   timezone,
   units,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  currentHour, // To force re-render when the hour changes
 }) => {
   const { t, i18n } = useTranslation('forecast');
   const locale = i18n.language;

--- a/src/components/weather/forecast/ForecastByHourList.tsx
+++ b/src/components/weather/forecast/ForecastByHourList.tsx
@@ -48,6 +48,7 @@ type ForecastByHourListProps = PropsFromRedux & {
   activeDayIndex: number;
   setActiveDayIndex: (i: number) => void;
   currentDayOffset: number;
+  currentHour: number;
 };
 
 const ForecastByHourList: React.FC<ForecastByHourListProps> = ({
@@ -59,6 +60,8 @@ const ForecastByHourList: React.FC<ForecastByHourListProps> = ({
   displayParams,
   clockType,
   units,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  currentHour, // just for re-rendering every hour
 }) => {
   const [currentIndex, setCurrentIndex] = useState<number>(0);
   const { colors, dark } = useTheme() as CustomTheme;

--- a/src/screens/WarningsScreen.tsx
+++ b/src/screens/WarningsScreen.tsx
@@ -92,7 +92,9 @@ const WarningsScreen: React.FC<WarningsScreenProps> = ({
         ) : (
           <>
             <WarningsPanel />
-            <WarningsWebViewPanel />
+            <WarningsWebViewPanel
+              updateInterval={(warningsConfig.updateInterval ?? 5) * 60 * 1000}
+            />
           </>
         )}
       </ScrollView>

--- a/src/screens/WeatherScreen.tsx
+++ b/src/screens/WeatherScreen.tsx
@@ -123,6 +123,8 @@ const WeatherScreen: React.FC<WeatherScreenProps> = ({
     updateWarnings();
   }, [location, updateForecast, updateObservation, updateWarnings]);
 
+  const currentHour = new Date().getHours();
+
   return (
     <GradientWrapper>
       <View>
@@ -132,8 +134,8 @@ const WeatherScreen: React.FC<WeatherScreenProps> = ({
           showsVerticalScrollIndicator={false}
           stickyHeaderIndices={announcements && [0]}>
           <Announcements style={styles.announcements} />
-          <NextHourForecastPanel />
-          <ForecastPanel />
+          <NextHourForecastPanel currentHour={currentHour} />
+          <ForecastPanel currentHour={currentHour} />
           <ObservationPanel />
         </ScrollView>
       </View>

--- a/src/store/forecast/selectors.ts
+++ b/src/store/forecast/selectors.ts
@@ -12,6 +12,9 @@ import constants, { DAY_LENGTH } from './constants';
 const selectForecastDomain: Selector<State, ForecastState> = (state) =>
   state.forecast;
 
+// To refresh forecast every hour
+const selectHour: Selector<State> = () => new Date().getHours();
+
 export const selectLoading = createSelector(
   selectForecastDomain,
   (forecast) => forecast.loading
@@ -27,24 +30,20 @@ const selectData = createSelector(
   (forecast) => forecast.data
 );
 
-const selectFetchTimestamp = createSelector(
-  selectForecastDomain,
-  (forecast) => forecast.fetchTimestamp
-);
-
 export const selectForecastAge = createSelector(
   selectForecastDomain,
   (forecast) => Date.now() - forecast.fetchSuccessTime
 );
 
 export const selectForecast = createSelector(
-  [selectData, selectGeoid, selectFetchTimestamp],
-  (items, geoid, timestamp) => {
+  [selectData, selectGeoid, selectHour],
+  (items, geoid) => {
+    const now = new Date();
     if (items) {
       const locationItems = items[!isNaN(geoid) ? geoid : 0];
       // filter out outdated items
       const filtered = locationItems?.filter(
-        (i) => i.epochtime * 1000 > timestamp
+        (i) => i.epochtime * 1000 > now.getTime()
       );
 
       return filtered || [];
@@ -59,7 +58,7 @@ export const selectNextHourForecast = createSelector(
 );
 
 export const selectForecastByDay = createSelector(
-  selectForecast,
+  [selectForecast],
   (forecast) =>
     forecast &&
     forecast.length > 0 &&


### PR DESCRIPTION
Modified `ConfigProvider` by adding `reloadInterval` (1 minute). Therefore components that are using existing `ReloaderContext` run their own own logic for updates every minute if the app is active.

The special case is that forecast views are refreshed when the hour changes.

Didn't implement layer specific logic for the map view, because felt that it would add too much complexity for little benefit. Most use cases (99.9% or something) still use old logic to check updates when the app becomes active and the new interval based logic is just for developers and users running the app in active always mode (the iPad on the wall etc.)

Also didn't add any new configuration options for `defaultConfig`, existing update intervals are still used.