### PR TITLE
issue-625: Added missing windSpeedMap values for knots unit

### DIFF
--- a/src/components/weather/sheets/WeatherInfoBottomSheet.tsx
+++ b/src/components/weather/sheets/WeatherInfoBottomSheet.tsx
@@ -103,6 +103,7 @@ const WeatherInfoBottomSheet: React.FC<WeatherInfoBottomSheetProps> = ({
     'km/h': ['1-11', '12-25', '26-47', '48-72', '73-115', '> 115'],
     mph: ['1-7', '8-16', '17-29', '30-45', '46-72', '> 72'],
     bft: ['1-4', '5-9', '10-17', '18-25', '26-41', '> 41'],
+    kn: ['1-6', '7-14', '15-26', '27-39', '40-62', '> 62'],
   } as { [key: string]: string[] };
 
   const temperatureUnit =


### PR DESCRIPTION
`windSpeedMap` was missing values for knots unit that caused crash when `WeatherInfoBottomSheet` was opened. Added values based on `m/s` values.