### PR TITLE
issue-620: Store dynamiconfig locally and use etag for updating it

### DIFF
--- a/src/config/ConfigProvider.tsx
+++ b/src/config/ConfigProvider.tsx
@@ -18,6 +18,7 @@ const ConfigProvider: React.FC<ConfigProviderProps> = ({
   timeout,
 }) => {
   const reloadInterval = 60000;
+  const [restored, setRestored] = useState<boolean>(false);
   const [updated, setUpdated] = useState<number>(0);
   const [shouldReload, setShouldReload] = useState<number>(0);
   const reloadIntervalRef = useRef<NodeJS.Timeout | null>(null);
@@ -35,6 +36,7 @@ const ConfigProvider: React.FC<ConfigProviderProps> = ({
 
     if (storedConfig && storedVersion === packageJSON.version) {
       Config.setDefaultConfig(JSON.parse(storedConfig));
+      setRestored(true);
     }
   };
 
@@ -78,11 +80,12 @@ const ConfigProvider: React.FC<ConfigProviderProps> = ({
   }, [checkUpdates, enabled]);
 
   useEffect(() => {
-    restoreStoredConfiguration().then(() => {
-      setUpdated(Date.now());
-      checkUpdates();
-    });
-  }, [checkUpdates]);
+    if (!restored) {
+      restoreStoredConfiguration().then(() => {
+        checkUpdates();
+      });
+    }
+  }, [checkUpdates, restored]);
 
   useEffect(() => {
     reloadIntervalRef.current = setInterval(
@@ -93,7 +96,7 @@ const ConfigProvider: React.FC<ConfigProviderProps> = ({
 
   return (
     <>
-      {(!enabled || updated > 0) && (
+      {(!enabled || restored || updated > 0) && (
         <ReloaderContext.Provider value={{ shouldReload }}>
           {children}
         </ReloaderContext.Provider>

--- a/src/utils/async_storage.ts
+++ b/src/utils/async_storage.ts
@@ -4,8 +4,17 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 export const LOCALE = 'locale';
 export const UNITS = 'units';
 export const THEME = 'theme';
+export const VERSION = 'version';
+export const DYNAMICCONFIG = 'dynamicconfig';
+export const DYNAMICCONFIG_ETAG = 'dynamicconfig_etag';
 
-type StorageKey = typeof LOCALE | typeof UNITS | typeof THEME;
+type StorageKey =
+  | typeof LOCALE
+  | typeof UNITS
+  | typeof THEME
+  | typeof VERSION
+  | typeof DYNAMICCONFIG
+  | typeof DYNAMICCONFIG_ETAG;
 
 export const getItem = async (key: StorageKey): Promise<string | null> => {
   try {


### PR DESCRIPTION
Optimized config loading by saving dynamiconfig locally and updating it only when etag header or app version changes. Amazon S3 calculates etag automatically for every document/file.