### PR TITLE
issue-690: Testing build for Android

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -129,20 +129,15 @@ jobs:
         run: |
           echo "GOOGLE_MAPS_API_KEY=${{ secrets.GOOGLE_MAPS_API_KEY }}" > .env
           chmod +x ./gradlew
-          bundle exec fastlane android build_apk
-        working-directory: android
-
-      - name: Rename APK 
-        run:
-          mv "./app/build/outputs/apk/release/app-release.apk" "./app/build/outputs/apk/release/latest.apk"
+          bundle exec fastlane android build_test_apk
         working-directory: android
 
       # Upload artifact
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: latest.apk
+          name: app-latest.apk
           path: |
-            ${{ github.workspace }}/android/app/build/outputs/apk/release/latest.apk
+            ${{ github.workspace }}/android/app/build/outputs/apk/latest/app-latest.apk
           retention-days: 7
           overwrite: true

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -132,6 +132,13 @@ android {
         debug {
             signingConfig signingConfigs.debug
         }
+        latest {
+            signingConfig signingConfigs.release
+            minifyEnabled enableProguardInReleaseBuilds
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            proguardFile "${rootProject.projectDir}/../node_modules/detox/android/detox/proguard-rules-app.pro"
+            matchingFallbacks = ['release']
+        }
         release {
             // Caution! In production, you need to generate your own keystore file.
             // see https://reactnative.dev/docs/signed-apk-android.

--- a/android/app/latest/.gitignore
+++ b/android/app/latest/.gitignore
@@ -1,2 +1,0 @@
-/output-metadata.json
-/app-latest.apk

--- a/android/app/latest/.gitignore
+++ b/android/app/latest/.gitignore
@@ -1,0 +1,2 @@
+/output-metadata.json
+/app-latest.apk

--- a/android/app/src/latest/AndroidManifest.xml
+++ b/android/app/src/latest/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <application
+        android:usesCleartextTraffic="true"
+        tools:targetApi="28"
+        tools:ignore="GoogleAppIndexingWarning"
+    />
+</manifest>

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -2,6 +2,7 @@
 <network-security-config>
     <domain-config cleartextTrafficPermitted="true">
         <domain includeSubdomains="true">10.0.2.2</domain>
+        <domain includeSubdomains="true">192.168.50.155</domain>
         <domain includeSubdomains="true">localhost</domain>
     </domain-config>
 </network-security-config>

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -70,6 +70,20 @@ platform :android do
             "android.injected.signing.key.password" => ENV["SIGNING_KEY_PASSWORD"]
         })
   end
+
+  # Build APK only
+  desc "Android build APK for testing"
+  lane :build_test_apk do
+  # Gradle clean
+        gradle(task: 'clean', project_dir: './')
+  # Gradle sign aab -file
+  gradle(task: 'assemble', build_type: "Latest", project_dir: './',properties: {
+            "android.injected.signing.store.file" => ENV["KEYSTORE"],
+            "android.injected.signing.store.password" => ENV["SIGNING_STORE_PASSWORD"],
+            "android.injected.signing.key.alias" => ENV["SIGNING_KEY_ALIAS"],
+            "android.injected.signing.key.password" => ENV["SIGNING_KEY_PASSWORD"]
+        })
+  end
   
   # Sign, build and deploy to Google Play Store
   desc "Sign, build, and deploy to Google Play Store"

--- a/android/fastlane/README.md
+++ b/android/fastlane/README.md
@@ -31,6 +31,14 @@ Increment build and version number and push to repository - Build number = versi
 
 Android build APK
 
+### android build_test_apk
+
+```sh
+[bundle exec] fastlane android build_test_apk
+```
+
+Android build APK for testing
+
 ### android build_sign_and_deploy
 
 ```sh

--- a/mockserver/data/config/config.json
+++ b/mockserver/data/config/config.json
@@ -1,1 +1,6 @@
-{}
+{
+  "weather": {
+    "apiUrl": "http://localhost:3000/timeseries",
+    "useCardinalsForWindDirection": true
+  }
+}

--- a/src/config/ConfigProvider.tsx
+++ b/src/config/ConfigProvider.tsx
@@ -23,7 +23,9 @@ const ConfigProvider: React.FC<ConfigProviderProps> = ({
   const [shouldReload, setShouldReload] = useState<number>(0);
   const reloadIntervalRef = useRef<NodeJS.Timeout | null>(null);
 
-  Config.setDefaultConfig(defaultConfig);
+  if (!Config.hasBeenSet) {
+    Config.setDefaultConfig(defaultConfig);
+  }
 
   if (timeout) {
     Config.setApiTimeout(timeout);

--- a/src/config/DynamicConfig.ts
+++ b/src/config/DynamicConfig.ts
@@ -22,6 +22,8 @@ class DynamicConfig {
 
   private updated: number;
 
+  public hasBeenSet = false;
+
   constructor() {
     this.apiUrl = undefined;
     this.updating = false;
@@ -31,11 +33,14 @@ class DynamicConfig {
 
   public setDefaultConfig(defaultConfig: ConfigType) {
     this.config = defaultConfig;
+    this.hasBeenSet = true;
+
     if (defaultConfig.dynamicConfig?.enabled) {
       let apiUrl = defaultConfig.dynamicConfig.apiUrl;
 
       // For testing we can override dynamic config url
       const launchArgs = LaunchArguments.value<LaunchArgs>();
+      console.log('launchArgs', launchArgs);
       if (launchArgs?.config) {
         apiUrl = launchArgs.config;
       }

--- a/src/config/DynamicConfig.ts
+++ b/src/config/DynamicConfig.ts
@@ -40,7 +40,6 @@ class DynamicConfig {
 
       // For testing we can override dynamic config url
       const launchArgs = LaunchArguments.value<LaunchArgs>();
-      console.log('launchArgs', launchArgs);
       if (launchArgs?.config) {
         apiUrl = launchArgs.config;
       }


### PR DESCRIPTION
- Added testing build (latest) for Android that allows http-traffic to mockserver
  - Otherwise same as release build 
  - named "latest" because build name can't start with test-prefix
- Fixed issue with DynamicConfig that caused DefaultConfig to overwrite DynamicConfig if response time for DynamicConfig was too fast and app initialization was still going 