### PR TITLE
issue-690: Use 10.0.2.2 instead of localhost with mockserver

### DIFF
--- a/mockserver/data/config/config.json
+++ b/mockserver/data/config/config.json
@@ -1,6 +1,6 @@
 {
   "weather": {
-    "apiUrl": "http://localhost:3000/timeseries",
+    "apiUrl": "http://10.0.2.2:3000/timeseries",
     "useCardinalsForWindDirection": true
   }
 }


### PR DESCRIPTION
localhost doesn't work well with Android emulator, because localhost is emulator itself. Changed DynamicConfig file to use 10.0.2.2 instead.

https://stackoverflow.com/questions/9808560/why-do-we-use-10-0-2-2-to-connect-to-local-web-server-instead-of-using-computer