### PR TITLE
issue-706: Android widgetConfig symbolic link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,4 +84,4 @@ buck-out/
 .env.production
 android/app/release/
 defaultConfig.ts
-widgetConfig.json
+/widgetConfig.json

--- a/android/app/src/main/assets/widgetConfig.json
+++ b/android/app/src/main/assets/widgetConfig.json
@@ -1,0 +1,1 @@
+../../../../../widgetConfig.json


### PR DESCRIPTION
Changed Android widgetConfig.json to symbolic link, so that it is enough to update one widgetConfig.json in project root.