### PR TITLE
issue-783: Removed 4x2 forecast widget from Android Manifest

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -87,6 +87,7 @@
             </intent-filter>
         </activity>
 
+        <!--
         <receiver android:name=".LargeForecastWidgetProvider" android:label="@string/large_widget" android:exported="false">
             <intent-filter>
                 <action android:name="fi.fmi.mobileweather.AUTO_UPDATE" />
@@ -99,6 +100,7 @@
                 <action android:name="android.appwidget.action.APPWIDGET_CONFIGURE" />
             </intent-filter>
         </activity>
+        -->
 
         <receiver android:name=".SmallWarningsWidgetProvider" android:label="@string/small_warnings_widget" android:exported="false">
             <intent-filter>


### PR DESCRIPTION
Keep the code, just hide from users.