### PR TITLE
issue-791: Check for invalid forecast data and error display improvements

### DIFF
--- a/mockserver/modifiers.mjs
+++ b/mockserver/modifiers.mjs
@@ -85,6 +85,11 @@ export const updateForecast = (json, geoid, mode) => {
       const epochtime = forecastStart + index * 3600;
       item.epochtime = epochtime;
 
+      item.localtime = new Date(epochtime * 1000)
+        .toISOString()
+        .replace(/[-:Z.]/g, '')
+        .substring(0, 13);
+
       if (item.sunrise && item.sunset && item.modtime) {
         if (item.sunrise && item.sunset && item.modtime) {
           item.sunrise = getSuntime(epochtime, item.sunrise);
@@ -97,6 +102,11 @@ export const updateForecast = (json, geoid, mode) => {
     } else {
       const epochtime = item.epochtime + interval;
 
+      item.localtime = new Date(epochtime * 1000)
+        .toISOString()
+        .replace(/[-:Z.]/g, '')
+        .substring(0, 13);
+
       if (epochtime > now.getTime() / 1000) {
         item.epochtime = epochtime;
 
@@ -105,7 +115,6 @@ export const updateForecast = (json, geoid, mode) => {
           item.sunset = getSuntime(epochtime, item.sunset);
           item.modtime = modtime;
         }
-
         itemsInFuture.push(item);
       }
     }

--- a/src/components/weather/forecast/DaySelectorList.tsx
+++ b/src/components/weather/forecast/DaySelectorList.tsx
@@ -14,9 +14,11 @@ import { converter, toPrecision } from '@utils/units';
 import PrecipitationStrip from './PrecipitationStrip';
 import { selectUnits } from '@store/settings/selectors';
 import { State } from '@store/types';
+import { selectForecastInvalidData } from '@store/forecast/selectors';
 
 const mapStateToProps = (state: State) => ({
   units: selectUnits(state),
+  invalidData: selectForecastInvalidData(state),
 });
 
 const connector = connect(mapStateToProps, {});
@@ -43,6 +45,7 @@ const DaySelectorList: React.FC<DaySelectorListProps> = ({
   setActiveDayIndex,
   dayData,
   units,
+  invalidData,
 }) => {
   const { colors, dark } = useTheme() as CustomTheme;
   const { t, i18n } = useTranslation();
@@ -90,16 +93,20 @@ const DaySelectorList: React.FC<DaySelectorListProps> = ({
     );
     const isActive = index === activeDayIndex;
 
-    const convertedMaxTemperature = toPrecision(
-      'temperature',
-      temperatureUnit,
-      converter(temperatureUnit, maxTemperature)
-    );
-    const convertedMinTemperature = toPrecision(
-      'temperature',
-      temperatureUnit,
-      converter(temperatureUnit, minTemperature)
-    );
+    const convertedMaxTemperature = invalidData
+      ? '-'
+      : toPrecision(
+          'temperature',
+          temperatureUnit,
+          converter(temperatureUnit, maxTemperature)
+        );
+    const convertedMinTemperature = invalidData
+      ? '-'
+      : toPrecision(
+          'temperature',
+          temperatureUnit,
+          converter(temperatureUnit, minTemperature)
+        );
 
     const weekdayAbbreviationFormat = locale === 'en' ? 'ddd' : 'dd';
     const dateFormat = locale === 'en' ? 'D MMM' : 'D.M.';

--- a/src/store/forecast/selectors.ts
+++ b/src/store/forecast/selectors.ts
@@ -57,6 +57,14 @@ export const selectNextHourForecast = createSelector(
   (forecast) => forecast && forecast[0]
 );
 
+export const selectForecastInvalidData = createSelector(
+  selectForecast,
+  (forecast) =>
+    forecast &&
+    forecast.length > 0 &&
+    forecast.every((timeStep) => timeStep.temperature === null)
+);
+
 export const selectForecastByDay = createSelector(
   [selectForecast],
   (forecast) =>


### PR DESCRIPTION
- Checks if all forecast timesteps have `null` temperature value and displays error
- Improved error display that errors are displayed only on tabs that they concern. Also allows more than one retry now.
- Added `localtime` to mock server forecast data, because current version needs it