### PR TITLE
issue-794: Static release url for Android APK

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -159,4 +159,10 @@ jobs:
           files: ${{ github.workspace }}/android/app/build/outputs/apk/latest/app-latest.apk
           token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: true
-          draft: false
+          draft: true
+
+      - name: Remove source code from release
+        run: |
+          gh release edit v1.0.0 --repo $GITHUB_REPOSITORY --draft=false --remove-files "Source code (zip)" "Source code (tar.gz)"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -155,7 +155,7 @@ jobs:
       - name: Update release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: latest
+          name: "Latest"
           files: ${{ github.workspace }}/android/app/build/outputs/apk/latest/app-latest.apk
           token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: true

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -150,3 +150,13 @@ jobs:
             ${{ github.workspace }}/android/app/build/outputs/apk/latest/app-latest.apk
           retention-days: 7
           overwrite: true
+
+      # Release to get static url for apk
+      - name: Update release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: latest
+          files: ${{ github.workspace }}/android/app/build/outputs/apk/latest/app-latest.apk
+          token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: true
+          draft: false

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -155,7 +155,7 @@ jobs:
       - name: Update release
         uses: softprops/action-gh-release@v2
         with:
-          name: "Latest"
+          tag_name: latest
           files: ${{ github.workspace }}/android/app/build/outputs/apk/latest/app-latest.apk
           token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: true

--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -159,10 +159,4 @@ jobs:
           files: ${{ github.workspace }}/android/app/build/outputs/apk/latest/app-latest.apk
           token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: true
-          draft: true
-
-      - name: Remove source code from release
-        run: |
-          gh release edit v1.0.0 --repo $GITHUB_REPOSITORY --draft=false --remove-files "Source code (zip)" "Source code (tar.gz)"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          draft: false


### PR DESCRIPTION
Creates releases to https://github.com/fmidev/weather-app/releases/tag/latest and the APK has static url that can be used in tests.