### PR TITLE
issue-794: Added updating latest tag

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -151,6 +151,14 @@ jobs:
           retention-days: 7
           overwrite: true
 
+      - name: Update latest tag
+        run: |
+          git fetch --tags
+          git tag -f latest  # Updates tag to latest commit
+          git push --force origin latest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       # Release to get static url for apk
       - name: Update release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
Seems that updating latest tag is required or otherwise releases page shows that the latest release is based on old commits.