### PR TITLE
issue-694: Small fix for only daily observations notification

### DIFF
--- a/src/components/weather/observation/Latest.tsx
+++ b/src/components/weather/observation/Latest.tsx
@@ -180,7 +180,7 @@ const Latest: React.FC<LatestProps> = ({
       {hoursSinceLatestObservation > 2 && dailyData.length === 0 && (
         <InfoMessage translationKey="tooOld" />
       )}
-      {data.length <= 2 && dailyData.length > 0 && (
+      {data.length <= 3 && dailyData.length > 0 && (
         <InfoMessage translationKey="onlyDailyValues" />
       )}
       {!!latestObservation && hoursSinceLatestObservation <= 2 && (


### PR DESCRIPTION
Seems that on winter time daily snow depth observations are part of normal observations and therefore larger amount of normal or instant observations must be allowed. 3 seems to be working for the stations mentioned in the ticket.