### PR TITLE
issue-820: Added logic for aurora borealis backgrounds

### DIFF
--- a/src/components/weather/NextHourForecastPanelWithWeatherBackground.tsx
+++ b/src/components/weather/NextHourForecastPanelWithWeatherBackground.tsx
@@ -34,6 +34,7 @@ import { setCurrentLocation } from '@store/location/actions';
 import IconButton from '@components/common/IconButton';
 import { WeatherStackParamList } from '@navigators/types';
 import NextHoursForecast from './NextHoursForecast';
+import { selectIsAuroraBorealisLikely } from '@store/observation/selector';
 
 const mapStateToProps = (state: State) => ({
   loading: selectLoading(state),
@@ -41,6 +42,7 @@ const mapStateToProps = (state: State) => ({
   timezone: selectTimeZone(state),
   units: selectUnits(state),
   location: selectCurrent(state),
+  isAuroraBorealisLikely : selectIsAuroraBorealisLikely(state)
 });
 
 const connector = connect(mapStateToProps, {});
@@ -57,6 +59,7 @@ const NextHourForecastPanelWithWeatherBackground: React.FC<NextHourForecastPanel
   timezone,
   units,
   location,
+  isAuroraBorealisLikely,
   currentHour, // To force re-render when the hour changes
 }) => {
   const { t, i18n } = useTranslation('forecast');
@@ -91,11 +94,6 @@ const NextHourForecastPanelWithWeatherBackground: React.FC<NextHourForecastPanel
     units?.precipitation.unitAbb ?? defaultUnits.precipitation;
 
   const currentTime = moment.unix(nextHourForecast.epochtime);
-  const weatherBackground = weatherBackgroundGetter(
-    nextHourForecast?.smartSymbol?.toString() || '0',
-    dark
-  );
-
   const numericOrDash = (val: string | undefined | null): string =>
     val && !Number.isNaN(val) ? val : '-';
 
@@ -137,6 +135,15 @@ const NextHourForecastPanelWithWeatherBackground: React.FC<NextHourForecastPanel
 
   // Either show UV or precipitation
   const showUv = nextHourForecast.precipitation1h === 0 || dark;
+
+  const auroraBorealis = nextHourForecast?.smartSymbol && nextHourForecast?.smartSymbol > 100
+                          && nextHourForecast?.totalCloudCover && nextHourForecast?.totalCloudCover <= 50
+                          && isAuroraBorealisLikely;
+
+  const weatherBackground = weatherBackgroundGetter(
+    auroraBorealis ? 'aurora' : nextHourForecast?.smartSymbol?.toString() || '0',
+    dark
+  );
 
   const textColor = nextHourForecast.smartSymbol && nextHourForecast.smartSymbol > 100 ? WHITE :  colors.primaryText;
 

--- a/src/components/weather/charts/TemperatureChart.tsx
+++ b/src/components/weather/charts/TemperatureChart.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { VictoryLine, VictoryGroup, VictoryScatter } from 'victory-native';
+import { VictoryLine, VictoryGroup } from 'victory-native';
 import { CustomTheme } from '@assets/colors';
 import { useTheme } from '@react-navigation/native';
 import chartTheme from '@assets/chartTheme';
@@ -15,14 +15,6 @@ const TemperatureChart: React.FC<ChartDataProps> = ({
 
   return (
     <VictoryGroup theme={chartTheme} width={chartWidth}>
-      {temperature && temperature.length > 0 && (
-          <VictoryScatter
-            data={temperature.filter(item => item.y !== null)}
-            domain={chartDomain}
-            size={1}
-            style={{ data: { stroke: colors.chartPrimaryLine } }}
-          />
-      )}
       {temperature && temperature.length > 0 && (
           <VictoryLine
             data={temperature}

--- a/src/components/weather/charts/TemperatureChart.tsx
+++ b/src/components/weather/charts/TemperatureChart.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { VictoryLine, VictoryGroup } from 'victory-native';
+import { VictoryLine, VictoryGroup, VictoryScatter } from 'victory-native';
 import { CustomTheme } from '@assets/colors';
 import { useTheme } from '@react-navigation/native';
 import chartTheme from '@assets/chartTheme';
@@ -16,12 +16,20 @@ const TemperatureChart: React.FC<ChartDataProps> = ({
   return (
     <VictoryGroup theme={chartTheme} width={chartWidth}>
       {temperature && temperature.length > 0 && (
-        <VictoryLine
-          data={temperature}
-          domain={chartDomain}
-          style={{ data: { stroke: colors.chartPrimaryLine } }}
-          interpolation="basis"
-        />
+          <VictoryScatter
+            data={temperature.filter(item => item.y !== null)}
+            domain={chartDomain}
+            size={1}
+            style={{ data: { stroke: colors.chartPrimaryLine } }}
+          />
+      )}
+      {temperature && temperature.length > 0 && (
+          <VictoryLine
+            data={temperature}
+            domain={chartDomain}
+            style={{ data: { stroke: colors.chartPrimaryLine } }}
+            interpolation="basis"
+          />
       )}
       {feelsLike && feelsLike.length > 0 && (
         <VictoryLine

--- a/src/components/weather/charts/TemperatureChart.tsx
+++ b/src/components/weather/charts/TemperatureChart.tsx
@@ -16,12 +16,12 @@ const TemperatureChart: React.FC<ChartDataProps> = ({
   return (
     <VictoryGroup theme={chartTheme} width={chartWidth}>
       {temperature && temperature.length > 0 && (
-          <VictoryLine
-            data={temperature}
-            domain={chartDomain}
-            style={{ data: { stroke: colors.chartPrimaryLine } }}
-            interpolation="basis"
-          />
+        <VictoryLine
+          data={temperature}
+          domain={chartDomain}
+          style={{ data: { stroke: colors.chartPrimaryLine } }}
+          interpolation="basis"
+        />
       )}
       {feelsLike && feelsLike.length > 0 && (
         <VictoryLine

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -67,6 +67,12 @@ export interface MapLayer {
   tileFormat?: string;
 }
 
+interface GeoMagneticObservations {
+  enabled: boolean;
+  producer: string;
+  countryCodes: string[];
+}
+
 interface Observation {
   updateInterval: number;
   numberOfStations: number;
@@ -75,6 +81,7 @@ interface Observation {
   timePeriod: number;
   parameters: (keyof ObservationParameters)[];
   dailyParameters?: (keyof DailyObservationParameters)[];
+  geoMagneticObservations?: GeoMagneticObservations;
 }
 
 interface ObservationEnabled extends Observation {

--- a/src/network/WeatherApi.ts
+++ b/src/network/WeatherApi.ts
@@ -8,6 +8,7 @@ import i18n from '@i18n';
 import axiosClient from '@utils/axiosClient';
 import { TimeseriesLocation } from '@store/location/types';
 import packageJSON from '../../package.json';
+import { findNearestGeoMagneticObservationStation, GeoMagneticStation, isAuroraBorealisLikely } from '@utils/geoMagneticStations';
 
 const isLocationValid = (
   location: ForecastLocation | ObservationLocation
@@ -73,7 +74,7 @@ export const getForecast = async (
 export const getObservation = async (
   location: ObservationLocation,
   country: string
-): Promise<ObservationDataRaw[]> => {
+): Promise<Array<ObservationDataRaw | boolean>> => {
   const {
     apiUrl,
     observation: {
@@ -84,6 +85,7 @@ export const getObservation = async (
       timePeriod,
       parameters,
       dailyParameters,
+      geoMagneticObservations,
     },
   } = Config.get('weather');
   const { language } = i18n;
@@ -103,8 +105,14 @@ export const getObservation = async (
     observationProducer as string
   );
 
+  const geoMagneticObservationsEnabled = geoMagneticObservations?.countryCodes.includes(country)
+                                          && location.latlon !== undefined
+                                          && geoMagneticObservations?.enabled === true;
+
+  const locationParam = location.geoid ? { geoid: location.geoid } : { latlon: location.latlon };
+
   const hourlyParams = {
-    ...location,
+    ...locationParam,
     numberofstations: numberOfStations,
     starttime: `-${timePeriod}h`,
     endtime: '0',
@@ -137,12 +145,45 @@ export const getObservation = async (
     ].join(','),
   };
 
-  const [observationData, dailyObservationData] = await Promise.all([
+  let nearestGeoMagneticStation: GeoMagneticStation | undefined;
+
+  if (geoMagneticObservationsEnabled && location.latlon) {
+    const [lat, lon] = location.latlon.split(',');
+    nearestGeoMagneticStation = findNearestGeoMagneticObservationStation(
+      parseFloat(lat),
+      parseFloat(lon)
+    );
+  }
+
+  const geoMagneticParams = {
+    starttime: '-1h',
+    param: ['distance','epochtime','fmisid','name','geomagneticRIndex'].join(','),
+    fmisid: nearestGeoMagneticStation?.fmisid,
+    producer: 'magnetic_disturbance_observations',
+    who: packageJSON.name,
+    format: 'json',
+    lang: language,
+    timestep: 'data',
+  };
+
+  const [observationData, dailyObservationData, geoMagneticObservationData] = await Promise.all([
     axiosClient({ url: apiUrl, params: hourlyParams }),
     dailyObservationsEnabled
       ? axiosClient({ url: apiUrl, params: dailyParams })
       : Promise.resolve({ data: {} }),
+    geoMagneticObservationsEnabled
+      ? axiosClient({ url: apiUrl, params: geoMagneticParams })
+      : Promise.resolve({ data: {} }),
   ]);
+
+  if (geoMagneticObservationsEnabled && nearestGeoMagneticStation && geoMagneticObservationData.data.length > 0) {
+    const { data } = geoMagneticObservationData
+    return [
+      observationData.data,
+      dailyObservationData.data,
+      isAuroraBorealisLikely(data[data.length - 1].geomagneticRIndex, nearestGeoMagneticStation),
+    ];
+  }
 
   return [observationData.data, dailyObservationData.data];
 };

--- a/src/network/WeatherApi.ts
+++ b/src/network/WeatherApi.ts
@@ -159,7 +159,7 @@ export const getObservation = async (
     starttime: '-1h',
     param: ['distance','epochtime','fmisid','name','geomagneticRIndex'].join(','),
     fmisid: nearestGeoMagneticStation?.fmisid,
-    producer: 'magnetic_disturbance_observations',
+    producer: geoMagneticObservations?.producer,
     who: packageJSON.name,
     format: 'json',
     lang: language,

--- a/src/screens/WeatherScreen.tsx
+++ b/src/screens/WeatherScreen.tsx
@@ -75,9 +75,10 @@ const WeatherScreen: React.FC<WeatherScreenProps> = ({
 
   const updateObservation = useCallback(() => {
     if (weatherConfig.observation.enabled) {
-      const observationLocation = location.id
-        ? { geoid: location.id }
-        : { latlon: `${location.lat},${location.lon}` };
+      const observationLocation = {
+        geoid: location.id,
+        latlon: `${location.lat},${location.lon}`
+      }
 
       fetchObservation(observationLocation, location.country);
       setObservationUpdated(Date.now());

--- a/src/store/forecast/types.ts
+++ b/src/store/forecast/types.ts
@@ -77,6 +77,7 @@ export interface ForecastParameters {
   dewPoint: number;
   uvCumulated: number;
   pressure: number;
+  totalCloudCover: number;
 }
 
 // copied almost as is from https://github.com/fmidev/mobileweather/blob/2b15990947985506a7b0711eef6df5c5826078b5/www/js/main.js#L554

--- a/src/store/observation/reducer.ts
+++ b/src/store/observation/reducer.ts
@@ -16,6 +16,7 @@ import {
 const INITIAL_STATE: ObservationState = {
   data: {},
   dailyData: {},
+  isAuroraBorealisLikely: false,
   error: false,
   id: 0,
   loading: false,
@@ -69,12 +70,13 @@ export default (
     }
 
     case FETCH_OBSERVATION_SUCCESS: {
-      const { data, stations } = formatData(action.payload.data[0]);
-      const { data: dailyData } = formatData(action.payload.data[1]);
+      const { data, stations } = formatData(action.payload.data[0] as ObservationDataRaw);
+      const { data: dailyData } = formatData(action.payload.data[1] as ObservationDataRaw);
       const newState = {
         ...state,
         data,
         dailyData,
+        isAuroraBorealisLikely: action.payload.data.length >= 3 && action.payload.data[2] === true,
         stations,
         id:
           action.payload.location.geoid || action.payload.location.latlon || 0,

--- a/src/store/observation/selector.ts
+++ b/src/store/observation/selector.ts
@@ -115,3 +115,8 @@ export const selectPreferredDailyParameters = createSelector(
     return result;
   }
 );
+
+export const selectIsAuroraBorealisLikely = createSelector(
+  selectObservationDomain,
+  (observation) => observation.isAuroraBorealisLikely === true
+);

--- a/src/store/observation/types.ts
+++ b/src/store/observation/types.ts
@@ -16,7 +16,7 @@ interface FetchObservation {
 interface FetchObservationSuccess {
   type: typeof FETCH_OBSERVATION_SUCCESS;
   payload: {
-    data: ObservationDataRaw[];
+    data: Array<ObservationDataRaw | boolean>;
     location: ObservationLocation;
   };
 }
@@ -75,6 +75,10 @@ export interface DailyObservationParameters {
   snowDepth06: number | null;
 }
 
+export interface GeoMagneticObservationParameters {
+  geomagneticRIndex: number | null;
+}
+
 export interface TimeStepData
   extends Partial<ObservationParameters & DailyObservationParameters> {
   epochtime: number;
@@ -120,6 +124,7 @@ export type StationId = {
 export interface ObservationState {
   data: ObservationData | undefined;
   dailyData: ObservationData | undefined;
+  isAuroraBorealisLikely: boolean | undefined;
   stations: StationInfo[] | [];
   stationId: StationId | undefined;
   id: Id;

--- a/src/utils/geoMagneticStations.ts
+++ b/src/utils/geoMagneticStations.ts
@@ -1,0 +1,61 @@
+export interface GeoMagneticStation {
+  lat: number;
+  lon: number;
+  organization: string;
+  country: string;
+  limit1: number;
+  limit2: number;
+  name: string;
+  fmisid: number;
+}
+
+const stations:Array<GeoMagneticStation> = [
+  { lat: 69.76, lon: 27.01, organization: "FMI", country: "FI", limit1: 55, limit2: 165, name: "Kevo", fmisid: 102035},
+  { lat: 69.05, lon: 20.79, organization: "FMI", country: "FI", limit1: 61, limit2: 210, name: "Kilpisjärvi", fmisid: 133879},
+  { lat: 68.56, lon: 27.29, organization: "FMI", country: "FI", limit1: 72, limit2: 275, name: "Ivalo", fmisid: 133847 },
+  { lat: 68.02, lon: 23.53, organization: "FMI", country: "FI", limit1: 75, limit2: 300, name: "Muonio", fmisid: 133749 },
+  { lat: 67.37, lon: 26.63, organization: "SGO", country: "FI", limit1: 74, limit2: 290, name: "Sodankylä", fmisid: 101932 },
+  { lat: 66.90, lon: 24.08, organization: "FMI", country: "FI", limit1: 73, limit2: 285, name: "Pello", fmisid: 133821 },
+  { lat: 65.90, lon: 26.41, organization: "FMI", country: "FI", limit1: 70, limit2: 240, name: "Ranua", fmisid: 100758},
+  { lat: 64.52, lon: 27.23, organization: "FMI", country: "FI", limit1: 68, limit2: 200, name: "Oulujärvi", fmisid: 133820},
+  { lat: 62.77, lon: 30.97, organization: "FMI", country: "FI", limit1: 64, limit2: 150, name: "Mekrijärvi", fmisid: 133891},
+  { lat: 62.25, lon: 26.60, organization: "FMI", country: "FI", limit1: 63, limit2: 140, name: "Hankasalmi", fmisid: 133846 },
+  { lat: 60.50, lon: 24.65, organization: "FMI", country: "FI", limit1: 60, limit2: 120, name: "Nurmijärvi", fmisid: 101149},
+  { lat: 58.26, lon: 26.46, organization: "FMI", country: "EE", limit1: 55, limit2: 100, name: "Tartto", fmisid: 133843}
+];
+
+const getDistance = (lat1: number, lon1: number, lat2: number, lon2: number): number => {
+  const toRad = (value: number) => (value * Math.PI) / 180;
+
+  const R = 6371;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) *
+    Math.sin(dLon / 2) * Math.sin(dLon / 2);
+
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+  return R * c;
+}
+
+export const findNearestGeoMagneticObservationStation = (lat: number, lon: number):GeoMagneticStation => {
+  let nearest = stations[0];
+  let shortestDistance = getDistance(lat, lon, nearest.lat, nearest.lon);
+
+  for (const station of stations.slice(1)) {
+    const distance = getDistance(lat, lon, station.lat, station.lon);
+    if (distance < shortestDistance) {
+      nearest = station;
+      shortestDistance = distance;
+    }
+  }
+
+  return nearest;
+}
+
+export const isAuroraBorealisLikely = (geomagneticRIndex: number, station: GeoMagneticStation):boolean => {
+  return geomagneticRIndex >= station.limit2
+}


### PR DESCRIPTION
Requires following changes to defaultConfig:

Add totalCloudCover to forecast-parameters

```
    forecast: {
      updateInterval: 30,
      timePeriod: 'data',
      data: [
        {
          producer: 'default',
          parameters: [
            'temperature',
            'feelsLike',
            'dewPoint',
            'smartSymbol',
            'windDirection',
            'windSpeedMS',
            'pop',
            'hourlymaximumgust',
            'relativeHumidity',
            'pressure',
            'precipitation1h',
            'windCompass8',
            'totalCloudCover',
          ],
        },
        { producer: 'uv', parameters: ['uvCumulated'] },
      ],
```

Add geoMagneticObservations to observation-section

```
      geoMagneticObservations: {
        enabled: true,
        producer: 'magnetic_disturbance_observations',
        countryCodes: ['FI', 'EE'],
      },
```