### PR TITLE
issue-877: Added support for language specific provider logos

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -185,6 +185,7 @@ type Themes = LightThemeEnabled | DarkThemeEnabled;
 
 interface OnboardingWizard {
   enabled: boolean;
+  languageSpecificLogo?: boolean;
 }
 
 interface Feedback {

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -20,17 +20,22 @@ import AccessibleTouchableOpacity from '@components/common/AccessibleTouchableOp
 
 import { GRAY_1, CustomTheme } from '@assets/colors';
 import { useOrientation } from '@utils/hooks';
+import { Config } from '@config';
+import { providerLogos } from '@assets/images';
 
 type OnboardingScreenProps = {
   navigation: StackNavigationProp<SetupStackParamList, 'Onboarding'>;
 };
 
 const OnboardingScreen: React.FC<OnboardingScreenProps> = ({ navigation }) => {
-  const { t } = useTranslation('onboarding');
+  const { languageSpecificLogo } = Config.get('onboardingWizard');
+  const { t, i18n } = useTranslation('onboarding');
   const { colors, dark } = useTheme() as CustomTheme;
   const [pageIndex, setPageIndex] = useState<number>(0);
   const titleRef = useRef() as React.MutableRefObject<Text>;
   const isLandscape = useOrientation();
+
+  const showLanguageSpecificLogo = languageSpecificLogo && providerLogos[i18n.language];
 
   const onboardingInfo = [
     {
@@ -126,15 +131,15 @@ const OnboardingScreen: React.FC<OnboardingScreenProps> = ({ navigation }) => {
         resizeMode="contain"
         source={
           dark
-            ? require('../assets/images/weather-background-dark.png')
-            : require('../assets/images/weather-background-light.png')
+            ? require(`../assets/images/weather-background-dark.png`)
+            : require(`../assets/images/weather-background-light.png`)
         }>
         <Image
           testID="onboarding_logo_image"
           source={
             dark
-              ? require('../assets/images/provider-logo-dark.png')
-              : require('../assets/images/provider-logo-light.png')
+              ? showLanguageSpecificLogo? providerLogos[i18n.language].dark : require(`../assets/images/provider-logo-dark.png`)
+              : showLanguageSpecificLogo ? providerLogos[i18n.language].light : require(`../assets/images/provider-logo-light.png`)
           }
           resizeMode="contain"
           style={styles.logo}

--- a/src/screens/SetupScreen.tsx
+++ b/src/screens/SetupScreen.tsx
@@ -19,6 +19,8 @@ import AccessibleTouchableOpacity from '@components/common/AccessibleTouchableOp
 
 import { GRAY_1, CustomTheme } from '@assets/colors';
 import { useOrientation } from '@utils/hooks';
+import { Config } from '@config';
+import { providerLogos } from '@assets/images';
 
 type SetupScreenProps = {
   setUpDone: () => void;
@@ -26,11 +28,13 @@ type SetupScreenProps = {
 };
 
 const SetupScreen: React.FC<SetupScreenProps> = ({ navigation, setUpDone }) => {
-  const { t } = useTranslation('setUp');
+  const { languageSpecificLogo } = Config.get('onboardingWizard');
+  const { t, i18n } = useTranslation('setUp');
   const { colors, dark } = useTheme() as CustomTheme;
   const [didViewTerms, setDidViewTerms] = useState<boolean>(false);
   const [pageIndex, setPageIndex] = useState<number>(0);
   const isLandscape = useOrientation();
+  const showLanguageSpecificLogo = languageSpecificLogo && providerLogos[i18n.language];
 
   const requestLocationPermissions = () => {
     const permission =
@@ -189,8 +193,8 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ navigation, setUpDone }) => {
         <Image
           source={
             dark
-              ? require('../assets/images/provider-logo-dark.png')
-              : require('../assets/images/provider-logo-light.png')
+              ? showLanguageSpecificLogo ? providerLogos[i18n.language].dark : require(`../assets/images/provider-logo-dark.png`)
+              : showLanguageSpecificLogo ? providerLogos[i18n.language].light : require(`../assets/images/provider-logo-light.png`)
           }
           resizeMode="contain"
           style={styles.logo}


### PR DESCRIPTION
Allows to specify language specific provider logos in weather-app-assets. Also needs configuration option `languageSpecificLogo: true` to OnboardingWizard configuration. If these are not specified uses default images like before.