### PR TITLE
issue-895: Units can be translated

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -701,5 +701,7 @@
     "crisisPrefix": "Warning:",
     "maintenancePrefix": "Attention:",
     "openInBrowser": "Open in browser"
+  },
+  "unitAbbreviations": {
   }
 }

--- a/i18n/fi.json
+++ b/i18n/fi.json
@@ -701,5 +701,7 @@
     "crisisPrefix": "Varoitus:",
     "maintenancePrefix": "Huomio:",
     "openInBrowser": "Avaa selaimessa"
+  },
+  "unitAbbreviations": {
   }
 }

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -701,5 +701,7 @@
     "crisisPrefix": "Varning:",
     "maintenancePrefix": "OBS:",
     "openInBrowser": "Öppna i webbläsaren"
+  },
+  "unitAbbreviations": {
   }
 }

--- a/src/components/weather/NextHourForecastPanel.tsx
+++ b/src/components/weather/NextHourForecastPanel.tsx
@@ -164,7 +164,7 @@ const NextHourForecastPanel: React.FC<NextHourForecastPanelProps> = ({
               accessibilityLabel={`${numericOrDash(temperatureValue)} ${t(
                 getForecastParameterUnitTranslationKey(`°${temperatureUnit}`)
               )} `}>
-              °{temperatureUnit}
+              °{t(`unitAbbreviations:${temperatureUnit}`)}
             </Text>
           </View>
         )}
@@ -190,7 +190,7 @@ const NextHourForecastPanel: React.FC<NextHourForecastPanelProps> = ({
                   <Text style={[styles.bold, styles.feelsLikeText]}>
                     {numericOrDash(feelsLikeValue)}
                   </Text>
-                  <Text style={styles.feelsLikeText}>°{temperatureUnit}</Text>
+                  <Text style={styles.feelsLikeText}>°{t(`unitAbbreviations:${temperatureUnit}`)}</Text>
                 </Text>
               </View>
               <Icon
@@ -252,7 +252,7 @@ const NextHourForecastPanel: React.FC<NextHourForecastPanelProps> = ({
                   {numericOrDash(windSpeedValue)}
                 </Text>
                 <Text style={[styles.text, { color: colors.hourListText }]}>
-                  {` ${windUnit}`}
+                  {` ${t(`unitAbbreviations:${windUnit}`)}`}
                 </Text>
               </View>
             </View>
@@ -278,7 +278,7 @@ const NextHourForecastPanel: React.FC<NextHourForecastPanelProps> = ({
                   precipitationValue?.replace('.', decimalSeparator) ||
                   (0).toFixed(1).replace('.', decimalSeparator)
                 }`}</Text>
-                {` ${precipitationUnit}`}
+                {` ${t(`unitAbbreviations:${precipitationUnit}`)}`}
               </Text>
             </>
           )}

--- a/src/components/weather/ObservationPanel.tsx
+++ b/src/components/weather/ObservationPanel.tsx
@@ -168,7 +168,7 @@ const ObservationPanel: React.FC<ObservationPanelProps> = ({
   );
   const title = `${currentStation?.name || ''} – ${t(
     'distance'
-  )} ${toStringWithDecimal(currentStation?.distance, decimalSeparator)} km`;
+  )} ${toStringWithDecimal(currentStation?.distance, decimalSeparator)} ${t('unitAbbreviations:km')}`;
   return (
     <View
       style={layout === 'fmi' ? styles.extraPadding : [

--- a/src/components/weather/charts/ChartYAxis.tsx
+++ b/src/components/weather/charts/ChartYAxis.tsx
@@ -34,6 +34,7 @@ const ChartYAxis: React.FC<ChartYAxisProps> = ({
 }) => {
   const { colors } = useTheme() as CustomTheme;
   const { t } = useTranslation();
+  const { t: unitTranslate } = useTranslation('unitAbbreviations');
 
   const defaultUnits = Config.get('settings').units;
   const precipitationUnit =
@@ -48,7 +49,7 @@ const ChartYAxis: React.FC<ChartYAxisProps> = ({
     return null;
   }
 
-  let labelText: any = chartYLabelText(chartType, units)[right ? 1 : 0];
+  let labelText: any = chartYLabelText(chartType, units, unitTranslate)[right ? 1 : 0];
   labelText =
     labelText.indexOf(':') > 0
       ? t(labelText).toLocaleLowerCase().split(' ')

--- a/src/components/weather/charts/Legend.tsx
+++ b/src/components/weather/charts/Legend.tsx
@@ -151,7 +151,7 @@ const ChartLegend: React.FC<ChartLegendProps> = ({
                 <Text
                   style={[styles.legendText, { color: colors.hourListText }]}>
                   {t('weather:charts:temperature').toLocaleLowerCase()} (°
-                  {temperatureUnit})
+                  {t(`unitAbbreviations:${temperatureUnit}`)})
                 </Text>
               </View>
             )}
@@ -161,7 +161,7 @@ const ChartLegend: React.FC<ChartLegendProps> = ({
                 <Text
                   style={[styles.legendText, { color: colors.hourListText }]}>
                   {t(`weather:charts:feelsLike`).toLocaleLowerCase()} (°
-                  {temperatureUnit})
+                  {t(`unitAbbreviations:${temperatureUnit}`)})
                 </Text>
               </View>
             )}
@@ -173,7 +173,7 @@ const ChartLegend: React.FC<ChartLegendProps> = ({
                 <Text
                   style={[styles.legendText, { color: colors.hourListText }]}>
                   {t(`weather:charts:dewPoint`).toLocaleLowerCase()} (°
-                  {temperatureUnit})
+                  {t(`unitAbbreviations:${temperatureUnit}`)})
                 </Text>
               </View>
             )}
@@ -196,7 +196,7 @@ const ChartLegend: React.FC<ChartLegendProps> = ({
             <Bar color={colors.rain[3]} />
             <Text style={[styles.legendText, { color: colors.hourListText }]}>
               {t('weather:charts:precipitationLight', {
-                unit: precipitationUnit,
+                unit: t(`unitAbbreviations:${precipitationUnit}`),
               }).toLocaleLowerCase()}
             </Text>
           </View>
@@ -206,7 +206,7 @@ const ChartLegend: React.FC<ChartLegendProps> = ({
             <Bar color={TRANSPARENT} />
             <Text style={[styles.legendText, { color: colors.hourListText }]}>
               {t('weather:charts:precipitationModerate', {
-                unit: precipitationUnit,
+                unit: t(`unitAbbreviations:${precipitationUnit}`),
               }).toLocaleLowerCase()}
             </Text>
           </View>
@@ -216,7 +216,7 @@ const ChartLegend: React.FC<ChartLegendProps> = ({
             <Bar color={colors.rain[8]} />
             <Text style={[styles.legendText, { color: colors.hourListText }]}>
               {t('weather:charts:precipitationHeavy', {
-                unit: precipitationUnit,
+                unit: t(`unitAbbreviations:${precipitationUnit}`),
               }).toLocaleLowerCase()}
             </Text>
           </View>
@@ -245,7 +245,7 @@ const ChartLegend: React.FC<ChartLegendProps> = ({
             <View style={styles.legendRow}>
               <Line />
               <Text style={[styles.legendText, { color: colors.hourListText }]}>
-                {t('weather:charts:windSpeed').toLocaleLowerCase()} ({windUnit})
+                {t('weather:charts:windSpeed').toLocaleLowerCase()} ({t(`unitAbbreviations:${windUnit}`)})
               </Text>
             </View>
           )}
@@ -255,7 +255,7 @@ const ChartLegend: React.FC<ChartLegendProps> = ({
             <View style={styles.legendRow}>
               <DashLine />
               <Text style={[styles.legendText, { color: colors.hourListText }]}>
-                {t('weather:charts:windGust').toLocaleLowerCase()} ({windUnit})
+                {t('weather:charts:windGust').toLocaleLowerCase()} ({t(`unitAbbreviations:${windUnit}`)})
               </Text>
             </View>
           )}
@@ -283,7 +283,7 @@ const ChartLegend: React.FC<ChartLegendProps> = ({
         <View style={styles.legendRow}>
           <Line />
           <Text style={[styles.legendText, { color: colors.hourListText }]}>
-            {t('weather:charts:pressure').toLocaleLowerCase()} ({pressureUnit})
+            {t('weather:charts:pressure').toLocaleLowerCase()} ({t(`unitAbbreviations:${pressureUnit}`)})
           </Text>
         </View>
       )}

--- a/src/components/weather/forecast/DaySelectorList.tsx
+++ b/src/components/weather/forecast/DaySelectorList.tsx
@@ -166,7 +166,7 @@ const DaySelectorList: React.FC<DaySelectorListProps> = ({
                     ? 'forecast:celsius'
                     : 'forecast:fahrenheit'
                 ),
-              })}>{`${convertedMinTemperature} ... ${convertedMaxTemperature}°${temperatureUnit}`}</Text>
+              })}>{`${convertedMinTemperature} ... ${convertedMaxTemperature}°${t(`unitAbbreviations:${temperatureUnit}`)}`}</Text>
           )}
         </AccessibleTouchableOpacity>
         {activeParameters.includes('precipitation1h') && (

--- a/src/components/weather/forecast/ForecastByHourList.tsx
+++ b/src/components/weather/forecast/ForecastByHourList.tsx
@@ -66,6 +66,7 @@ const ForecastByHourList: React.FC<ForecastByHourListProps> = ({
   const [currentIndex, setCurrentIndex] = useState<number>(0);
   const { colors, dark } = useTheme() as CustomTheme;
   const { t } = useTranslation('forecast');
+  const { t: unitTranslate } = useTranslation('unitAbbreviations');
   const { excludeDayLength } = Config.get('weather').forecast;
 
   const virtualizedList = useRef() as React.MutableRefObject<
@@ -358,7 +359,7 @@ const ForecastByHourList: React.FC<ForecastByHourListProps> = ({
                         styles.bold,
                         { color: colors.hourListText },
                       ]}>
-                      {`${dayHours} h ${dayMinutes} min`}
+                      {`${dayHours} ${unitTranslate('h')} ${dayMinutes} ${unitTranslate('min')}`}
                     </Text>
                   </View>
                 </>

--- a/src/components/weather/forecast/ForecastListHeaderColumn.tsx
+++ b/src/components/weather/forecast/ForecastListHeaderColumn.tsx
@@ -11,6 +11,7 @@ import { DisplayParameters } from '@store/forecast/types';
 import { Config } from '@config';
 import { UnitMap } from '@store/settings/types';
 import LinearGradient from 'react-native-linear-gradient';
+import { useTranslation } from 'react-i18next';
 
 type ForecastListHeaderColumnProps = {
   displayParams: [number, DisplayParameters][];
@@ -25,6 +26,7 @@ const ForecastListHeaderColumn: React.FC<ForecastListHeaderColumnProps> = ({
 }) => {
   const { colors, dark } = useTheme() as CustomTheme;
   const defaultUnits = Config.get('settings').units;
+  const { t } = useTranslation('unitAbbreviations');
 
   const lightGradient = [
     'rgba(238, 239, 241, 0.64)',
@@ -73,7 +75,7 @@ const ForecastListHeaderColumn: React.FC<ForecastListHeaderColumnProps> = ({
                 <Icon name="wind" color={colors.hourListText} />
                 <Text
                   style={[styles.panelText, { color: colors.hourListText }]}>
-                  {units?.wind.unitAbb ?? defaultUnits.wind}
+                  {t(units?.wind.unitAbb ?? defaultUnits.wind)}
                 </Text>
               </View>
             );
@@ -91,7 +93,7 @@ const ForecastListHeaderColumn: React.FC<ForecastListHeaderColumnProps> = ({
                 <Icon name="gust" color={colors.hourListText} />
                 <Text
                   style={[styles.panelText, { color: colors.hourListText }]}>
-                  {units?.wind.unitAbb ?? defaultUnits.wind}
+                  {t(units?.wind.unitAbb ?? defaultUnits.wind)}
                 </Text>
               </View>
             );
@@ -109,7 +111,7 @@ const ForecastListHeaderColumn: React.FC<ForecastListHeaderColumnProps> = ({
                 <Icon name="precipitation" color={colors.hourListText} />
                 <Text
                   style={[styles.panelText, { color: colors.hourListText }]}>
-                  {units?.precipitation.unitAbb ?? defaultUnits.precipitation}
+                  {t(units?.precipitation.unitAbb ?? defaultUnits.precipitation)}
                 </Text>
               </View>
             );
@@ -147,7 +149,7 @@ const ForecastListHeaderColumn: React.FC<ForecastListHeaderColumnProps> = ({
                 ]}>
                 <Text
                   style={[styles.panelText, { color: colors.hourListText }]}>
-                  RH%
+                  {t('RH%')}
                 </Text>
               </View>
             );
@@ -165,7 +167,7 @@ const ForecastListHeaderColumn: React.FC<ForecastListHeaderColumnProps> = ({
                 ]}>
                 <Text
                   style={[styles.panelText, { color: colors.hourListText }]}>
-                  {units?.pressure.unitAbb ?? defaultUnits.pressure}
+                  {t(units?.pressure.unitAbb ?? defaultUnits.pressure)}
                 </Text>
               </View>
             );
@@ -183,7 +185,7 @@ const ForecastListHeaderColumn: React.FC<ForecastListHeaderColumnProps> = ({
                 ]}>
                 <Text
                   style={[styles.panelText, { color: colors.hourListText }]}>
-                  UV
+                  {t('UV')}
                 </Text>
               </View>
             );

--- a/src/components/weather/observation/DailyObservationRow.tsx
+++ b/src/components/weather/observation/DailyObservationRow.tsx
@@ -19,6 +19,7 @@ const DailyObservationRow: React.FC<DailyObservationRowProps> = ({
   data,
 }) => {
   const { t, i18n } = useTranslation('observation');
+  const { t: unitTranslate } = useTranslation('unitAbbreviations');
   const locale = i18n.language;
   const decimalSeparator = locale === 'en' ? '.' : ',';
 
@@ -56,7 +57,8 @@ const DailyObservationRow: React.FC<DailyObservationRowProps> = ({
       param.includes('snowDepth') ? 0 : 1,
       undefined,
       true,
-      decimalSeparator
+      decimalSeparator,
+      unitTranslate
     );
 
     if (secondParam) {
@@ -67,7 +69,8 @@ const DailyObservationRow: React.FC<DailyObservationRowProps> = ({
         1,
         undefined,
         true,
-        decimalSeparator
+        decimalSeparator,
+        unitTranslate
       )}`;
     }
 

--- a/src/components/weather/observation/Latest.tsx
+++ b/src/components/weather/observation/Latest.tsx
@@ -41,6 +41,7 @@ const Latest: React.FC<LatestProps> = ({
 }) => {
   const { colors } = useTheme() as CustomTheme;
   const { t, i18n } = useTranslation('observation');
+  const { t: unitTranslate } = useTranslation('unitAbbreviations');
   const locale = i18n.language;
   const { parameters } = Config.get('weather').observation;
   const decimalSeparator = locale === 'en' ? '.' : ',';
@@ -121,7 +122,7 @@ const Latest: React.FC<LatestProps> = ({
           return null;
         }
 
-        const unit = getParameterUnit(parameter, units);
+        const unit = getParameterUnit(parameter, units, unitTranslate);
         let value = getObservationCellValue(
           latestObservation,
           altParameter && parameters?.includes(altParameter)
@@ -131,7 +132,7 @@ const Latest: React.FC<LatestProps> = ({
           decimals,
           divider || 1,
           false,
-          decimalSeparator
+          decimalSeparator,
         );
 
         if (parameter === 'totalCloudCover' && value !== '-') {

--- a/src/components/weather/observation/List.tsx
+++ b/src/components/weather/observation/List.tsx
@@ -51,6 +51,7 @@ const List: React.FC<ListProps> = ({
   units,
 }) => {
   const { t, i18n } = useTranslation('observation');
+  const { t: unitTranslate } = useTranslation('unitAbbreviations');
   const { colors } = useTheme() as CustomTheme;
   const { parameters, dailyParameters } = Config.get('weather').observation;
 
@@ -136,7 +137,8 @@ const List: React.FC<ListProps> = ({
               ]}>
               {`${t(`measurements.maxAndMinTemperatures`)} ${getParameterUnit(
                 param,
-                units
+                units,
+                unitTranslate
               )}`}
             </Text>
           );
@@ -151,7 +153,7 @@ const List: React.FC<ListProps> = ({
               styles.bold,
               { color: colors.hourListText },
             ]}>
-            {`${t(`measurements.${param}`)} ${getParameterUnit(param, units)}`}
+            {`${t(`measurements.${param}`)} ${getParameterUnit(param, units, unitTranslate)}`}
           </Text>
         );
       })}

--- a/src/components/weather/sheets/ParamsBottomSheet.tsx
+++ b/src/components/weather/sheets/ParamsBottomSheet.tsx
@@ -147,7 +147,7 @@ const ParamsBottomSheet: React.FC<ParamsBottomSheetProps> = ({
               styles.withMarginRight,
               { color: colors.hourListText },
             ]}>
-            {getUnitForParameter(param)}
+            {t(`unitAbbreviations:${getUnitForParameter(param)}`)}
           </Text>
         )}
         {param === UV_CUMULATED && (
@@ -163,7 +163,7 @@ const ParamsBottomSheet: React.FC<ParamsBottomSheetProps> = ({
         )}
         <Text style={[styles.text, { color: colors.hourListText }]}>
           {t(`paramsBottomSheet.${param}`, {
-            unit: getUnitForParameter(param),
+            unit: t(`unitAbbreviations:${getUnitForParameter(param)}`),
           })}
         </Text>
       </View>

--- a/src/components/weather/sheets/WeatherInfoBottomSheet.tsx
+++ b/src/components/weather/sheets/WeatherInfoBottomSheet.tsx
@@ -256,7 +256,7 @@ const WeatherInfoBottomSheet: React.FC<WeatherInfoBottomSheetProps> = ({
                 <Text style={[styles.text, { color: colors.hourListText }]}>
                   {t('weatherInfoBottomSheet.hourlyForecastedTemperature', {
                     unit:
-                      units?.temperature.unitAbb ?? defaultUnits.temperature,
+                      t(`unitAbbreviations:${units?.temperature.unitAbb ?? defaultUnits.temperature}`),
                   })}
                 </Text>
               </View>
@@ -275,7 +275,7 @@ const WeatherInfoBottomSheet: React.FC<WeatherInfoBottomSheetProps> = ({
                 </View>
                 <Text style={[styles.text, { color: colors.hourListText }]}>
                   {t('weatherInfoBottomSheet.feelsLikeTemperature', {
-                    unit: temperatureUnit,
+                    unit: t(`unitAbbreviations:${temperatureUnit}`)
                   })}
                 </Text>
               </View>
@@ -295,7 +295,7 @@ const WeatherInfoBottomSheet: React.FC<WeatherInfoBottomSheetProps> = ({
                   </View>
                   <Text style={[styles.text, { color: colors.hourListText }]}>
                     {t('weatherInfoBottomSheet.windSpeedAndDirection', {
-                      unit: windUnit,
+                      unit: t(`unitAbbreviations:${windUnit}`)
                     })}
                   </Text>
                 </View>
@@ -343,7 +343,7 @@ const WeatherInfoBottomSheet: React.FC<WeatherInfoBottomSheetProps> = ({
                       styles.unitText,
                       { color: colors.hourListText },
                     ]}>
-                    {`${windSpeedMap[windUnit][0]} ${windUnit}`}
+                    {`${windSpeedMap[windUnit][0]} ${t(`unitAbbreviations:${windUnit}`)}`}
                   </Text>
                   <Text style={[styles.text, { color: colors.hourListText }]}>
                     {t('weatherInfoBottomSheet.light')}
@@ -356,7 +356,7 @@ const WeatherInfoBottomSheet: React.FC<WeatherInfoBottomSheetProps> = ({
                       styles.unitText,
                       { color: colors.hourListText },
                     ]}>
-                    {`${windSpeedMap[windUnit][1]} ${windUnit}`}
+                    {`${windSpeedMap[windUnit][1]} ${t(`unitAbbreviations:${windUnit}`)}`}
                   </Text>
                   <Text style={[styles.text, { color: colors.hourListText }]}>
                     {t('weatherInfoBottomSheet.moderate')}
@@ -369,7 +369,7 @@ const WeatherInfoBottomSheet: React.FC<WeatherInfoBottomSheetProps> = ({
                       styles.unitText,
                       { color: colors.hourListText },
                     ]}>
-                    {`${windSpeedMap[windUnit][2]} ${windUnit}`}
+                    {`${windSpeedMap[windUnit][2]} ${t(`unitAbbreviations:${windUnit}`)}`}
                   </Text>
                   <Text style={[styles.text, { color: colors.hourListText }]}>
                     {t('weatherInfoBottomSheet.strongBreeze')}
@@ -382,7 +382,7 @@ const WeatherInfoBottomSheet: React.FC<WeatherInfoBottomSheetProps> = ({
                       styles.unitText,
                       { color: colors.hourListText },
                     ]}>
-                    {`${windSpeedMap[windUnit][3]} ${windUnit}`}
+                    {`${windSpeedMap[windUnit][3]} ${t(`unitAbbreviations:${windUnit}`)}`}
                   </Text>
                   <Text style={[styles.text, { color: colors.hourListText }]}>
                     {t('weatherInfoBottomSheet.gale')}
@@ -395,7 +395,7 @@ const WeatherInfoBottomSheet: React.FC<WeatherInfoBottomSheetProps> = ({
                       styles.unitText,
                       { color: colors.hourListText },
                     ]}>
-                    {`${windSpeedMap[windUnit][4]} ${windUnit}`}
+                    {`${windSpeedMap[windUnit][4]} ${t(`unitAbbreviations:${windUnit}`)}`}
                   </Text>
                   <Text style={[styles.text, { color: colors.hourListText }]}>
                     {t('weatherInfoBottomSheet.storm')}
@@ -408,7 +408,7 @@ const WeatherInfoBottomSheet: React.FC<WeatherInfoBottomSheetProps> = ({
                       styles.unitText,
                       { color: colors.hourListText },
                     ]}>
-                    {`${windSpeedMap[windUnit][5]} ${windUnit}`}
+                    {`${windSpeedMap[windUnit][5]} ${t(`unitAbbreviations:${windUnit}`)}`}
                   </Text>
                   <Text style={[styles.text, { color: colors.hourListText }]}>
                     {t('weatherInfoBottomSheet.hurricane')}
@@ -430,7 +430,7 @@ const WeatherInfoBottomSheet: React.FC<WeatherInfoBottomSheetProps> = ({
                 </View>
                 <Text style={[styles.text, { color: colors.hourListText }]}>
                   {t('weatherInfoBottomSheet.precipitation', {
-                    unit: precipitationUnit,
+                    unit: t(`unitAbbreviations:${precipitationUnit}`),
                   })}
                 </Text>
               </View>
@@ -500,7 +500,7 @@ const WeatherInfoBottomSheet: React.FC<WeatherInfoBottomSheetProps> = ({
                 </View>
                 <Text style={[styles.text, { color: colors.hourListText }]}>
                   {t('weatherInfoBottomSheet.dewPoint', {
-                    unit: temperatureUnit,
+                    unit: t(`unitAbbreviations:${temperatureUnit}`),
                   })}
                 </Text>
               </View>
@@ -542,7 +542,7 @@ const WeatherInfoBottomSheet: React.FC<WeatherInfoBottomSheetProps> = ({
                 </View>
                 <Text style={[styles.text, { color: colors.hourListText }]}>
                   {t('weatherInfoBottomSheet.pressure', {
-                    unit: pressureUnit,
+                    unit: t(`unitAbbreviations:${pressureUnit}`),
                   })}
                 </Text>
               </View>

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -272,7 +272,7 @@ const SettingsScreen: React.FC<Props> = ({
                         style={[styles.text, { color: colors.text }]}
                         testID={`${key}_unitAbb`}>
                         {key === 'temperature' ? '°' : ''}
-                        {units[key].unitAbb}
+                        {t(`unitAbbreviations:${units[key].unitAbb}`)}
                       </Text>
                     </View>
                     {unitTypesByKey(key) && (

--- a/src/utils/chart.ts
+++ b/src/utils/chart.ts
@@ -181,7 +181,7 @@ export const getTickFormat =
   (locale: string, clockType: ClockType, daily?: boolean) => (tick: any) =>
     tickFormat(tick, locale, clockType, daily);
 
-export const chartYLabelText = (chartType: ChartType, units?: UnitMap) => {
+export const chartYLabelText = (chartType: ChartType, units?: UnitMap, t?: (key:string) => string) => {
   const defaultUnits = Config.get('settings').units;
 
   const temperatureUnit =
@@ -195,24 +195,24 @@ export const chartYLabelText = (chartType: ChartType, units?: UnitMap) => {
     case 'humidity':
       return ['%'];
     case 'temperature':
-      return [`°${temperatureUnit}`];
+      return [`°${t ? t(temperatureUnit) : temperatureUnit}`];
     case 'pressure':
-      return [pressureUnit];
+      return [t ? t(pressureUnit) : pressureUnit];
     case 'visCloud':
       return ['km', 'weather:charts:totalCloudCover'];
     case 'precipitation':
-      return [precipitationUnit, '%'];
+      return [t ? t(precipitationUnit) : precipitationUnit, '%'];
     case 'wind':
-      return [windUnit];
+      return [t ? t(windUnit) : windUnit];
     case 'uv':
-      return ['UV'];
+      return [t ? t('UV') : 'UV'];
     case 'snowDepth':
-      return ['cm'];
+      return [t ? t('cm') : 'cm'];
     case 'cloud':
-      return ['m'];
+      return [t ? t('m') : 'm'];
     case 'weather':
     case 'daily':
-      return [`°${temperatureUnit}`, precipitationUnit];
+      return [`°${ t ? t(temperatureUnit) : temperatureUnit}`, t ? t(precipitationUnit) : precipitationUnit];
     default:
       return [''];
   }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -216,12 +216,14 @@ export const getObservationCellValue = (
   decimals?: number,
   divider?: number,
   showUnit?: boolean,
-  decimalSeparator: ',' | '.' = ','
+  decimalSeparator: ',' | '.' = ',',
+  t?: (key: string) => string,
 ): string => {
   const unitAbb = unit.replace('°', ''); // get rid of ° in temperature units
   const unitParameterObject = UNITS.find((x) =>
     x.unitTypes.find((unitDefinition) => unitDefinition.unitAbb === unitAbb)
   );
+  const translatedUnit = t ? t(unitAbb) : unitAbb;
 
   const divideWith = divider || 1;
   if (!item || !param) return '-';
@@ -244,7 +246,7 @@ export const getObservationCellValue = (
       : Number(value).toFixed(decimals || 0)
     )
       .toString()
-      .replace('.', decimalSeparator)} ${showUnit ? unit : ''}`.trim();
+      .replace('.', decimalSeparator)} ${showUnit ? translatedUnit : ''}`.trim();
   }
   return '-';
 };
@@ -276,24 +278,25 @@ export const getLatestObservationAvoidingMissingValues = (
 
 export const getParameterUnit = (
   param: keyof (ObsTimeStepData | ForTimeStepData),
-  units?: UnitMap
+  units?: UnitMap,
+  t?: (key: string) => string
 ): string => {
   const { wind, temperature, precipitation, pressure } =
     Config.get('settings').units;
   switch (param) {
     case 'precipitation1h':
     case 'ri_10min':
-      return units?.precipitation.unitAbb ?? precipitation;
+      return t ? t(units?.precipitation.unitAbb ?? precipitation) : units?.precipitation.unitAbb ?? precipitation;
     case 'humidity':
       return '%';
     case 'temperature':
     case 'dewPoint':
-      return `°${units?.temperature.unitAbb ?? temperature}`;
+      return t ? `°${ t(units?.temperature.unitAbb ?? temperature) }` : `°${ units?.temperature.unitAbb ?? temperature}`;
     case 'windSpeedMS':
     case 'windGust':
-      return units?.wind.unitAbb ?? wind;
+      return t ? t(units?.wind.unitAbb ?? wind) : units?.wind.unitAbb ?? wind;
     case 'pressure':
-      return units?.pressure.unitAbb ?? pressure;
+      return t ? t(units?.pressure.unitAbb ?? pressure) : units?.pressure.unitAbb ?? pressure;
     case 'visibility':
       return 'km';
     case 'snowDepth':


### PR DESCRIPTION
Added support for legacy/default UI, because current need is there. Unit translations can be added to translation files like this:

```
"unitAbbreviations": {
   "hpa": "mbar"  
}
```

By default `unitAbbreviations` can be empty and default unit names are used.