### PR TITLE
issue-867: Modal improvements

### DIFF
--- a/src/components/weather/forecast/ModalContent.tsx
+++ b/src/components/weather/forecast/ModalContent.tsx
@@ -27,6 +27,7 @@ type ModalContentProps = PropsFromRedux & {
   timeStamp: number;
   onClose: () => void;
   onDayChange: (forward: boolean) => void;
+  initialPosition: 'start' | 'end';
 };
 
 const DailyModal: React.FC<ModalContentProps> = ({
@@ -34,7 +35,8 @@ const DailyModal: React.FC<ModalContentProps> = ({
   activeDayIndex,
   timeStamp,
   onClose,
-  onDayChange
+  onDayChange,
+  initialPosition
 }) => {
   const { t } = useTranslation('forecast');
   const { colors } = useTheme() as CustomTheme;
@@ -77,7 +79,10 @@ const DailyModal: React.FC<ModalContentProps> = ({
           />
         </View>
       </View>
-      <ModalForecast data={data ? data[moment(timeStamp).format('D.M.')] : []} />
+      <ModalForecast
+        data={data ? data[moment(timeStamp).format('D.M.')] : []}
+        initialPosition={initialPosition}
+      />
     </View>
   );
 };

--- a/src/components/weather/forecast/ModalForecast.tsx
+++ b/src/components/weather/forecast/ModalForecast.tsx
@@ -6,7 +6,7 @@ import {
   StyleSheet,
   NativeSyntheticEvent,
   NativeScrollEvent,
-  Pressable,
+  FlatList,
   useWindowDimensions,
 } from 'react-native';
 import { useTranslation } from 'react-i18next';
@@ -25,7 +25,7 @@ import { DAY_LENGTH } from '@store/forecast/constants';
 import { Config } from '@config';
 import ForecastListColumn from './ForecastListColumn';
 import ForecastListHeaderColumn from './ForecastListHeaderColumn';
-import { FlatList, ScrollView } from 'react-native-gesture-handler';
+
 import TimeSelectButtonGroup from './TimeSelectButtonGroup';
 
 const mapStateToProps = (state: State) => ({
@@ -362,16 +362,15 @@ const ModalForecast: React.FC<ModalForecastProps> = ({
           });
         }}
       />
-      <ScrollView style={[styles.table, { maxHeight: maxTableHeight }]}>
+      <View style={[styles.table, { maxHeight: maxTableHeight }]}>
         <View style={styles.row}>
           <ForecastListHeaderColumn displayParams={displayParams} units={units} modal />
-          <View style={styles.listContainer}>
             <FlatList
               ref={flatListRef}
               data={data}
               keyExtractor={(item) => `${item.epochtime}`}
               renderItem={({ item }: any) => (
-                <Pressable>
+                <View style={styles.flex} onStartShouldSetResponder={() => true}>
                   <ForecastListColumn
                     clockType={clockType}
                     data={item}
@@ -379,19 +378,18 @@ const ModalForecast: React.FC<ModalForecastProps> = ({
                     units={units}
                     modal
                   />
-                </Pressable>
+                </View>
               )}
               onScroll={handleOnScroll}
               horizontal
               showsHorizontalScrollIndicator={false}
             />
-          </View>
         </View>
         {displayParams
           .map((displayParam) => displayParam[1])
           .includes(DAY_LENGTH) &&
           !excludeDayLength && <DayDurationRow />}
-      </ScrollView>
+      </View>
     </>
   );
 };
@@ -453,6 +451,8 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
   },
+  flex: {
+    flex: 1,}
 });
 
 export default memo(connector(ModalForecast));

--- a/src/components/weather/forecast/Vertical10DaysForecast.tsx
+++ b/src/components/weather/forecast/Vertical10DaysForecast.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, useWindowDimensions } from 'react-native';
+import { View, Text, StyleSheet, useWindowDimensions, GestureResponderEvent, PanResponderGestureState } from 'react-native';
 import Modal from 'react-native-modal';
 import moment from 'moment';
 import { useTheme } from '@react-navigation/native';
@@ -237,9 +237,15 @@ const Vertical10DaysForecast: React.FC<DaySelectorListProps> = ({
         backdropOpacity={0.5}
         onSwipeComplete={ () => setModalVisible(false ) }
         onBackButtonPress={ () => setModalVisible(false ) }
-        swipeDirection={['up', 'down']}
-        propagateSwipe={true}
-        scrollHorizontal={true}
+        onBackdropPress={ () => setModalVisible(false ) }
+        swipeDirection={['down', 'up']}
+        propagateSwipe={(_: GestureResponderEvent, gestureState: PanResponderGestureState) => {
+          const { dx, dy } = gestureState;
+          if (Math.abs(dx) > Math.abs(dy)) {
+            return true;
+          }
+          return false;
+        }}
       >
         <View style={styles.centeredView}>
           <View style={[styles.modalView, { backgroundColor: colors.modalBackground }]}>

--- a/src/components/weather/forecast/Vertical10DaysForecast.tsx
+++ b/src/components/weather/forecast/Vertical10DaysForecast.tsx
@@ -15,7 +15,8 @@ import { converter, getForecastParameterUnitTranslationKey, toPrecision } from '
 import PrecipitationStrip from './PrecipitationStrip';
 import { selectUnits } from '@store/settings/selectors';
 import { State } from '@store/types';
-import { selectForecastInvalidData } from '@store/forecast/selectors';
+import { selectForecastInvalidData, selectDisplayParams } from '@store/forecast/selectors';
+
 import Icon from '@assets/Icon';
 import { uppercaseFirst } from '@utils/helpers';
 import ModalContent from './ModalContent';
@@ -23,6 +24,7 @@ import ModalContent from './ModalContent';
 const mapStateToProps = (state: State) => ({
   units: selectUnits(state),
   invalidData: selectForecastInvalidData(state),
+  displayParams: selectDisplayParams(state),
 });
 
 const connector = connect(mapStateToProps, {});
@@ -48,7 +50,9 @@ const Vertical10DaysForecast: React.FC<DaySelectorListProps> = ({
   dayData,
   units,
   invalidData,
+  displayParams,
 }) => {
+  const dimensions = useWindowDimensions();
   const { colors, dark } = useTheme() as CustomTheme;
   const { t, i18n } = useTranslation();
   const locale = i18n.language;
@@ -69,6 +73,10 @@ const Vertical10DaysForecast: React.FC<DaySelectorListProps> = ({
   const [modalVisible, setModalVisible] = useState(false);
   const [modalTimeStamp, setModalTimeStamp] = useState(0);
   const [modalActiveDayIndex, setModalActiveDayIndex] = useState(0);
+  const [initialPosition, setInitialPosition] = useState<'start' | 'end'>('start');
+
+  const shouldHorizontalScroll = dimensions.height < 500 ||
+                                (dimensions.height < 900 && displayParams.length >= 12);
 
   const rowRenderer = ({
     item,
@@ -139,6 +147,7 @@ const Vertical10DaysForecast: React.FC<DaySelectorListProps> = ({
     const showModal = (epochtime: number, activeDayIndex: number) => {
       setModalTimeStamp(epochtime*1000);
       setModalActiveDayIndex(activeDayIndex);
+      setInitialPosition('start');
       setModalVisible(true);
     }
 
@@ -240,6 +249,8 @@ const Vertical10DaysForecast: React.FC<DaySelectorListProps> = ({
         onBackdropPress={ () => setModalVisible(false ) }
         swipeDirection={['down', 'up']}
         propagateSwipe={(_: GestureResponderEvent, gestureState: PanResponderGestureState) => {
+          if (shouldHorizontalScroll) return true;
+
           const { dx, dy } = gestureState;
           if (Math.abs(dx) > Math.abs(dy)) {
             return true;
@@ -253,6 +264,7 @@ const Vertical10DaysForecast: React.FC<DaySelectorListProps> = ({
               activeDayIndex={modalActiveDayIndex}
               timeStamp={modalTimeStamp}
               onClose={() => setModalVisible(false) }
+              initialPosition={initialPosition}
               onDayChange={ (forward: boolean) => {
                 let newDayIndex = forward ? modalActiveDayIndex + 1 : modalActiveDayIndex - 1;
                 if (newDayIndex < 0) newDayIndex = 0;
@@ -260,6 +272,11 @@ const Vertical10DaysForecast: React.FC<DaySelectorListProps> = ({
 
                 setModalActiveDayIndex(newDayIndex);
                 setModalTimeStamp(dayData[newDayIndex].timeStamp*1000);
+                if (forward) {
+                  setInitialPosition('start');
+                } else {
+                  setInitialPosition('end');
+                }
               }}
             />
           </View>


### PR DESCRIPTION
- Improved modal close by swipe. It is now possible to swipe to close from anywhere in the modal, not just from header. Only when there are lot of forecast parameters or little vertical space (landscape displays) then vertical scrollview prevents swipe to close from scrollview content.
- Hides time selection buttons from tablets and landscape displays giving more space for weather content
- Backward and forward buttons go to either start or end of the day forecast, not to random position anymore