### PR TITLE
issue-935: Added default image for news

### DIFF
--- a/src/components/news/NewsView.tsx
+++ b/src/components/news/NewsView.tsx
@@ -55,7 +55,17 @@ const NewsView: React.FC<NewsProps> = ({ item, titleNumberOfLines, gridLayout })
         accessibilityHint={t('readMore')}
         onPress={() => { openLink(item.type, item.id) }}
       >
-        <Image src={item.imageUrl} style={[styles.image]} />
+        { !item.imageUrl ? (
+          <Image
+            source={require('@assets/images/press-release-default.webp')}
+            style={styles.image}
+          />
+        ) : (
+          <Image
+            src={item.imageUrl}
+            style={styles.image}
+          />
+        )}
       </AccessibleTouchableOpacity>
       <SimpleButton
         accessibilityHint={t('readMore')}

--- a/src/network/NewsApi.ts
+++ b/src/network/NewsApi.ts
@@ -12,13 +12,21 @@ const getNews = async (language: string): Promise<NewsItem[]> => {
   const url = apiUrl[language]+`?limit=${numberOfNews}`;
   const { data } = await axiosClient({ url });
 
-  const newsItems = data.items.map((item:any):NewsItem => {
+  const newsItems = data.items.flatMap((item:any):NewsItem | [] => {
+    if (!item.sys?.id || !item.fields?.title || !item.fields?.type
+       || !item.sys?.createdAt || !item.sys?.updatedAt || !item.fields?.site
+    ) {
+      return [];
+    }
+
+    const imageMissing = !item.fields?.thumbnail?.fields?.image;
+
     return {
       id: item.sys.id,
       title: item.fields.title,
       type: item.fields.type,
-      imageUrl: 'https:' + item.fields.thumbnail.fields.image.fields.file.url,
-      imageAlt: item.fields.thumbnail.fields.image.fields.altText,
+      imageUrl: imageMissing ? null : 'https:' + item.fields.thumbnail.fields.image.fields.file.url,
+      imageAlt: imageMissing ? '' : item.fields.thumbnail.fields.image.fields.altText,
       createdAt: item.sys.createdAt,
       updatedAt: item.sys.updatedAt,
       language: item.fields.site

--- a/src/store/news/types.ts
+++ b/src/store/news/types.ts
@@ -32,7 +32,7 @@ export interface NewsItem {
   id: string;
   type: string;
   title: string;
-  imageUrl: string;
+  imageUrl: string | null;
   imageAlt: string;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
Default image is used if the news item is missing image. Also improved failure safety by checking news attributes before reading them.