### PR TITLE
issue-976: Improved location name accessibility

### DIFF
--- a/src/components/weather/NextHourForecastPanelWithWeatherBackground.tsx
+++ b/src/components/weather/NextHourForecastPanelWithWeatherBackground.tsx
@@ -171,10 +171,11 @@ const NextHourForecastPanelWithWeatherBackground: React.FC<NextHourForecastPanel
             }}
             circular
           />
-          <View style={styles.locationTextContainer} accessible accessibilityRole="header">
+          <View style={styles.locationTextContainer}>
             <AccessibleTouchableOpacity
               onPress={() => { navigation.navigate('Search') }}
-              accessibilityLabel={t('navigation:search')}
+              accessibilityRole="button"
+              accessibilityLabel={`${location.name}${location.area ? `, ${location.area}` : ''}, ${t('navigation:search')}`}
             >
               <Text
                 numberOfLines={1}


### PR DESCRIPTION
Because of AccessibleTouchableOpacity location name was read as "Search". Changed it to to "name, area, search". For example "Tikkurila, Vantaa, haku".

Also changed accessibilityRole to button.

