### PR TITLE
issue-1011: Fixes for warning info sheet

### DIFF
--- a/src/components/warnings/InfoSheet.tsx
+++ b/src/components/warnings/InfoSheet.tsx
@@ -16,12 +16,16 @@ import useOrientation from '@utils/hooks';
 import { WarningType } from '@store/warnings/types';
 import { knownWarningTypes } from '@store/warnings/constants';
 import SeverityBar from './SeverityBar';
-import WarningSymbol from './WarningsSymbol';
 import TypeColorRow from './TypeColorRow';
+import WarningIcon from './WarningIcon';
 
 type InfoSheetProps = {
   onClose: () => void;
 };
+
+const showPhysical = (type: WarningType): boolean => {
+  return type.toLowerCase().includes('wind');
+}
 
 const InfoSheet: React.FC<InfoSheetProps> = ({ onClose }) => {
   const { t } = useTranslation('map');
@@ -29,6 +33,10 @@ const InfoSheet: React.FC<InfoSheetProps> = ({ onClose }) => {
   const isLandscape = useOrientation();
   const severities = [0, 1, 2, 3];
   const severityColors = [GREEN, YELLOW, ORANGE, RED];
+  const physical = {
+    windIntensity: 21,
+    windDirection: 225,
+  };
 
   const SeverityBarRow = ({ severity }: { severity: number }) => (
     <View style={styles.row}>
@@ -44,7 +52,7 @@ const InfoSheet: React.FC<InfoSheetProps> = ({ onClose }) => {
   const TypeRow = ({ type }: { type: WarningType }) => (
     <View style={styles.row}>
       <View style={[styles.iconWrapper]}>
-        <WarningSymbol type={type} severity="Moderate" />
+        <WarningIcon type={type} severity={1} physical={ showPhysical(type) ? physical : undefined }/>
       </View>
       <Text style={[styles.text, { color: colors.hourListText }]}>
         {t(`warnings:types:${type}`).toLocaleLowerCase()}

--- a/src/components/warnings/WarningIcon.tsx
+++ b/src/components/warnings/WarningIcon.tsx
@@ -18,6 +18,10 @@ const resolveSeverity = (severity: Severity): number => {
   return 0;
 }
 
+const showPhysical = (type: WarningType): boolean => {
+  return type.toLowerCase().includes('wind');
+}
+
 const WarningIcon: React.FC<WarningIconProps> = (
   { severity, severityDescription, type, physical }
 ) => {
@@ -34,7 +38,7 @@ const WarningIcon: React.FC<WarningIconProps> = (
           transform: [{ rotate: (180 + physical?.windDirection) + 'deg' }]
         } : {}}/>
       )}
-      { severityValue > 0 && physical?.windIntensity && (
+      { severityValue > 0 && physical?.windIntensity && showPhysical(type) && (
         <Text style={styles.text}>{physical?.windIntensity}</Text>
       )}
     </View>

--- a/src/components/warnings/WarningsSymbol.tsx
+++ b/src/components/warnings/WarningsSymbol.tsx
@@ -25,7 +25,6 @@ const WarningSymbol: React.FC<WarningSymbolProps> = ({
     trafficWeather: 'traffic-weather',
     pedestrianSafety: 'pedestrian-safety',
     forestFireWeather: 'forest-fire-weather',
-    grassFireWeather: 'grass-fire-weather',
     hotWeather: 'hot-weather',
     coldWeather: 'hot-weather',
     uvNote: 'uv-note',

--- a/src/store/warnings/constants.ts
+++ b/src/store/warnings/constants.ts
@@ -2,7 +2,6 @@
 export const knownWarningTypes = [
   'thunderstorm',
   'forestFireWeather',
-  'grassFireWeather',
   'wind',
   'trafficWeather',
   'rain',


### PR DESCRIPTION
Fixed missing icons and labels. Also fixed some related issues like that there is no grass fire warning anymore and incorrect mappings between warning types and icons.