### PR TITLE
Fixed weather bar screen reader pronunciation for negative temperatures

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -99,6 +99,7 @@
     "today": "Today",
     "tomorrow": "Tomorrow",
     "precipitationMissing": "Precipitation amount missing",
+    "minus": "minus",
     "params": {
       "temperature": "temperature: {{ value }} {{ unit }}.",
       "feelsLike": "feels like: {{ value }} {{ unit }}.",

--- a/i18n/fi.json
+++ b/i18n/fi.json
@@ -99,6 +99,7 @@
     "today": "Tänään",
     "tomorrow": "Huomenna",
     "precipitationMissing": "Sademäärä puuttuu",
+    "minus": "miinus",
     "params": {
       "temperature": "lämpötila: {{ value }} {{ unit }}.",
       "feelsLike": "tuntuu kuin: {{ value }} {{ unit }}.",

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -247,7 +247,7 @@
       "km/h": "kilometer per sekund",
       "mph": "engelska mil per timme",
       "bft": "beaufort",
-      "kn": "knopar",
+      "kn": "knop",
       "hPa": "hehtopascal",
       "mbar": "millibar",
       "mmHg": "millimeter kvicksilver",

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -99,6 +99,7 @@
     "today": "Idag",
     "tomorrow": "Imorgon",
     "precipitationMissing": "Nederbörd saknas",
+    "minus": "minus",
     "params": {
       "temperature": "temperatur: {{ value }} {{ unit }}.",
       "feelsLike": "känns som: {{ value }} {{ unit }}.",
@@ -237,7 +238,7 @@
       "minimumGroundTemperature06": "Markens lägsta temperatur",
       "snowDepth06": "Snödjup på morgonen"
     },
-    "paramsUnits": {
+    "paramUnits": {
       "mm": "millimeter",
       "%": "procent",
       "°C": "celcius grader",
@@ -246,6 +247,7 @@
       "km/h": "kilometer per sekund",
       "mph": "engelska mil per timme",
       "bft": "beaufort",
+      "kn": "knopar",
       "hPa": "hehtopascal",
       "mbar": "millibar",
       "mmHg": "millimeter kvicksilver",

--- a/src/components/weather/NextHourForecastPanelWithWeatherBackground.tsx
+++ b/src/components/weather/NextHourForecastPanelWithWeatherBackground.tsx
@@ -23,7 +23,7 @@ import { selectTimeZone, selectCurrent } from '@store/location/selector';
 import { selectUnits } from '@store/settings/selectors';
 import { weatherBackgroundGetter } from '@assets/images/backgrounds';
 
-import { getGeolocation } from '@utils/helpers';
+import { formatAccessibleTemperature, getGeolocation } from '@utils/helpers';
 import { WHITE } from '@assets/colors';
 
 import { Config } from '@config';
@@ -207,7 +207,10 @@ const NextHourForecastPanelWithWeatherBackground: React.FC<NextHourForecastPanel
           </Text>
         </View>
         <View style={styles.row}>
-          <View style={[styles.row, styles.alignStart]} accessible>
+          <View style={[styles.row, styles.alignStart]} accessible
+            accessibilityLabel={`${formatAccessibleTemperature(temperatureValue, t)} ${t(
+              getForecastParameterUnitTranslationKey(`°${temperatureUnit}`)
+            )}`}>
             <Text
               style={[
                 styles.temperatureText,
@@ -217,9 +220,7 @@ const NextHourForecastPanelWithWeatherBackground: React.FC<NextHourForecastPanel
             </Text>
             <Text
               style={[styles.unitText, { color: textColor }]}
-              accessibilityLabel={`${numericOrDash(temperatureValue)} ${t(
-                getForecastParameterUnitTranslationKey(`°${temperatureUnit}`)
-              )} `}>
+              >
               °{temperatureUnit}
             </Text>
           </View>

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -310,6 +310,17 @@ export const getParameterUnit = (
   }
 };
 
+export function formatAccessibleTemperature(
+  val: string | number | undefined | null,
+  t: (key: string) => string): string {
+  if (val === null || val === undefined || val === '') return '-';
+  const num = typeof val === 'number' ? val : Number(val);
+  if (isNaN(num)) return '-';
+  const valuePart =
+    num < 0 ? `${t('forecast:minus')} ${Math.abs(num)}` : `${num}`;
+  return `${valuePart}`;
+}
+
 // https://gist.github.com/johndyer/0dffbdd98c2046f41180c051f378f343
 const getEaster = (year: number): Date => {
   const f = Math.floor;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -310,12 +310,14 @@ export const getParameterUnit = (
   }
 };
 
-export function formatAccessibleTemperature(
+export const formatAccessibleTemperature = (
   val: string | number | undefined | null,
-  t: (key: string) => string): string {
+  t: (key: string) => string): string  => {
   if (val === null || val === undefined || val === '') return '-';
-  const num = typeof val === 'number' ? val : Number(val);
+
+  const num = Number(val);
   if (isNaN(num)) return '-';
+
   const valuePart =
     num < 0 ? `${t('forecast:minus')} ${Math.abs(num)}` : `${num}`;
   return `${valuePart}`;


### PR DESCRIPTION
How to test:

- Open weather page and search a cold area (currently e.g. Grytviken, GS)
- Enable screen reader
- Make sure negative degrees on the forecast panel are pronounced as negative (e.g. "minus two degrees celsius")