### PR TITLE
issue-1046: Fixed sunrise and sunset times

### DIFF
--- a/src/components/weather/forecast/ModalForecast.tsx
+++ b/src/components/weather/forecast/ModalForecast.tsx
@@ -99,8 +99,7 @@ const ModalForecast: React.FC<ModalForecastProps> = ({
 
   // eslint-disable-next-line react/no-unstable-nested-components
   const DayDurationRow = () => {
-    let step = data[0];
-
+    const step = data[data.length - 1];
     const sunrise = moment(`${step.sunrise}Z`);
     const sunset = moment(`${step.sunset}Z`);
     const sunriseSunsetDiff = Math.abs(sunset.diff(sunrise, 'hours'));


### PR DESCRIPTION
Seems that first timesteps of daily data contain suntimes for previous day, so use the last timestep of daily data.