### PR TITLE
issue-1059: Added layout-option to disable forecast background color

### DIFF
--- a/src/components/weather/GradientWrapper.tsx
+++ b/src/components/weather/GradientWrapper.tsx
@@ -3,6 +3,7 @@ import { connect, ConnectedProps } from 'react-redux';
 import { StyleSheet } from 'react-native';
 import LinearGradient from 'react-native-linear-gradient';
 import { useTheme } from '@react-navigation/native';
+import { Config } from '@config';
 
 import { State } from '@store/types';
 import {
@@ -39,6 +40,11 @@ const GradientWrapper: React.FC<GradientWrapperProps> = ({
   nextHourForecast,
 }) => {
   const { colors, dark } = useTheme() as CustomTheme;
+  const weatherConfig = Config.get('weather');
+
+  if (weatherConfig.layout === 'legacyWithoutBackgroundColor') {
+    return <>{children}</>;
+  }
 
   const colorsDark = [colors.background, colors.background];
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -236,7 +236,7 @@ export interface ConfigType {
   };
   weather: {
     apiUrl: string;
-    layout?: 'default' | 'fmi';
+    layout?: 'default' | 'fmi' | 'legacyWithoutBackgroundColor';
     forecast: {
       ageWarning?: number;
       updateInterval: number;


### PR DESCRIPTION
`layout: 'legacyWithoutBackgroundColor'` disables next hour forecast background