### PR TITLE
issue-959: Implemented Terms of Use display & accept when changes

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -629,6 +629,7 @@
   },
   "setUp": {
     "termsAndConditions": "Terms of Use",
+    "termsAndConditionsChanged": "The Terms of Use have changed",
     "termsAndConditionsDescription": "You must accept the terms of use to use the service. Learn more about the Terms of Use by tapping the Terms of Use link.",
     "accept": "Accept",
     "location": "Location",

--- a/i18n/fi.json
+++ b/i18n/fi.json
@@ -629,6 +629,7 @@
   },
   "setUp": {
     "termsAndConditions": "Käyttöehdot",
+    "termsAndConditionsChanged": "Käyttöehdot on päivitetty",
     "termsAndConditionsDescription": "Käyttääksesi palvelua, sinun tulee hyväksyä käyttöehdot. Tutustu käyttö-\nehtoihin painamalla Käyttöehdot-linkkiä.",
     "accept": "Hyväksy",
     "location": "Sijainti",

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -629,6 +629,7 @@
   },
   "setUp": {
     "termsAndConditions": "Användarvillkor",
+    "termsAndConditionsChanged": "Användarvillkoren har ändrats",
     "termsAndConditionsDescription": "För att använda tjänsten måste du godkänna applikationens användarvillkor. Bekanta dig med användningsvillkoren genom att klicka på länken Användningsvillkor.",
     "accept": "Godkänn",
     "location": "Läge",

--- a/src/config/DynamicConfig.ts
+++ b/src/config/DynamicConfig.ts
@@ -7,7 +7,7 @@ import packageJSON from '../../package.json';
 import type { LaunchArgs } from '@navigators/types';
 
 // Top level features that are not supported in dynamic config
-const BLACKLIST = ['dynamicConfig'] as Array<keyof ConfigType>;
+const BLACKLIST = ['dynamicConfig', 'onboardingWizard'] as Array<keyof ConfigType>;
 
 class DynamicConfig {
   private config!: ConfigType;

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -187,6 +187,7 @@ type Themes = LightThemeEnabled | DarkThemeEnabled;
 interface OnboardingWizard {
   enabled: boolean;
   languageSpecificLogo?: boolean;
+  termsOfUseChanged?: boolean;
 }
 
 interface Feedback {

--- a/src/navigators/TabNavigator.tsx
+++ b/src/navigators/TabNavigator.tsx
@@ -60,6 +60,7 @@ import {
 import {
   selectInitialTab,
   selectDidLaunchApp,
+  selectTermsOfUseAccepted,
 } from '@store/navigation/selectors';
 import {
   setNavigationTab as setNavigationTabAction,
@@ -84,6 +85,7 @@ const mapStateToProps = (state: State) => ({
   initialTab: selectInitialTab(state),
   theme: selectTheme(state),
   didLaunchApp: selectDidLaunchApp(state),
+  termsOfUseAccepted: selectTermsOfUseAccepted(state),
 });
 
 const mapDispatchToProps = {
@@ -112,6 +114,7 @@ const Navigator: React.FC<Props> = ({
   theme,
   initialTab,
   didLaunchApp,
+  termsOfUseAccepted,
   setDidLaunchApp,
   fetchAnnouncements,
 }) => {
@@ -370,7 +373,7 @@ const Navigator: React.FC<Props> = ({
 
   const SetupStackScreen = () => (
     <SetupStack.Navigator
-      initialRouteName="Onboarding"
+      initialRouteName={ didLaunchApp && !termsOfUseAccepted ? 'SetupScreen' : 'Onboarding' }
       screenOptions={{ gestureEnabled: false }}>
       <SetupStack.Screen
         name="Onboarding"
@@ -388,6 +391,7 @@ const Navigator: React.FC<Props> = ({
             setUpDone={() => {
               setDidLaunchApp();
             }}
+            termsOfUseChanged={ !termsOfUseAccepted }
           />
         )}
       </SetupStack.Screen>
@@ -413,7 +417,7 @@ const Navigator: React.FC<Props> = ({
     return null;
   }
 
-  if (!didLaunchApp && onboardingWizardEnabled && launchArgs?.e2e !== true) {
+  if ((!didLaunchApp || !termsOfUseAccepted) && onboardingWizardEnabled && launchArgs?.e2e !== true) {
     return (
       <NavigationContainer theme={useDarkTheme ? darkTheme : lightTheme}>
         <SetupStackScreen />

--- a/src/screens/SetupScreen.tsx
+++ b/src/screens/SetupScreen.tsx
@@ -25,9 +25,14 @@ import { providerLogos } from '@assets/images';
 type SetupScreenProps = {
   setUpDone: () => void;
   navigation: StackNavigationProp<SetupStackParamList, 'SetupScreen'>;
+  termsOfUseChanged: boolean;
 };
 
-const SetupScreen: React.FC<SetupScreenProps> = ({ navigation, setUpDone }) => {
+const SetupScreen: React.FC<SetupScreenProps> = ({
+  navigation,
+  setUpDone,
+  termsOfUseChanged
+}) => {
   const { languageSpecificLogo } = Config.get('onboardingWizard');
   const { t, i18n } = useTranslation('setUp');
   const { colors, dark } = useTheme() as CustomTheme;
@@ -47,6 +52,14 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ navigation, setUpDone }) => {
         setUpDone();
       })
       .catch((e) => console.error(e));
+  };
+
+  const acceptTermsOfUse = () => {
+    if (termsOfUseChanged) {
+      setUpDone()
+    } else {
+      setPageIndex(1);
+    }
   };
 
   const PermissionComponent: React.FC<{
@@ -207,11 +220,11 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ navigation, setUpDone }) => {
         ]}>
         {pageIndex === 0 && (
           <PermissionComponent
-            title={t('termsAndConditions')}
+            title={ termsOfUseChanged ? t('termsAndConditionsChanged') : t('termsAndConditions')}
             description={t('termsAndConditionsDescription')}
             primaryButtonText={t('accept')}
             secondaryButtonText={t('termsAndConditions')}
-            onPrimaryButtonPress={() => setPageIndex(1)}
+            onPrimaryButtonPress={acceptTermsOfUse}
             onSecondaryButtonPress={() => {
               if (!didViewTerms) setDidViewTerms(true);
               navigation.navigate('TermsAndConditions');
@@ -234,25 +247,27 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ navigation, setUpDone }) => {
           />
         )}
       </View>
-      <View
-        testID="setup_pagination"
-        style={[styles.row, styles.center, styles.height10]}>
+      { !termsOfUseChanged && (
         <View
-          testID="setup_pagination_0"
-          style={[
-            styles.pagination,
-            styles.marginRight,
-            { backgroundColor: pageIndex === 0 ? colors.primary : GRAY_1 },
-          ]}
-        />
-        <View
-          testID="setup_pagination_1"
-          style={[
-            styles.pagination,
-            { backgroundColor: pageIndex === 1 ? colors.primary : GRAY_1 },
-          ]}
-        />
-      </View>
+          testID="setup_pagination"
+          style={[styles.row, styles.center, styles.height10]}>
+          <View
+            testID="setup_pagination_0"
+            style={[
+              styles.pagination,
+              styles.marginRight,
+              { backgroundColor: pageIndex === 0 ? colors.primary : GRAY_1 },
+            ]}
+          />
+          <View
+            testID="setup_pagination_1"
+            style={[
+              styles.pagination,
+              { backgroundColor: pageIndex === 1 ? colors.primary : GRAY_1 },
+            ]}
+          />
+        </View>
+      )}
     </SafeAreaView>
   );
 };

--- a/src/store/navigation/reducer.ts
+++ b/src/store/navigation/reducer.ts
@@ -5,10 +5,12 @@ import {
   SET_NAVIGATION_TAB,
   SET_DID_LAUNCH_APP,
 } from './types';
+import packageJSON from '../../../package.json';
 
 const INITIAL_STATE: NavigationState = {
   tab: 'Weather',
   didLaunchApp: false,
+  termsOfUseAccepted: false,
 };
 
 export default (
@@ -27,6 +29,7 @@ export default (
       return {
         ...state,
         didLaunchApp: true,
+        termsOfUseAccepted: packageJSON.version,
       };
     }
 
@@ -38,5 +41,5 @@ export default (
 
 export const navigationPersist: PersistConfig = {
   key: 'navigation',
-  whitelist: ['tab', 'didLaunchApp'],
+  whitelist: ['tab', 'didLaunchApp', 'termsOfUseAccepted'],
 };

--- a/src/store/navigation/selectors.ts
+++ b/src/store/navigation/selectors.ts
@@ -6,6 +6,8 @@ import {
   Selector,
 } from 'reselect';
 import { NavigationState } from './types';
+import { Config } from '@config';
+import packageJSON from '../../../package.json';
 
 const selectNavigationDomain: Selector<State, NavigationState> = (state) =>
   state.navigation;
@@ -25,4 +27,18 @@ export const selectInitialTab = createInitialSelector(
 export const selectDidLaunchApp = createSelector(
   selectNavigationDomain,
   (navigation) => navigation.didLaunchApp
+);
+
+export const selectTermsOfUseAccepted = createSelector(
+  selectNavigationDomain,
+  (navigation) => {
+    const { termsOfUseChanged } = Config.get('onboardingWizard')
+
+    if (termsOfUseChanged && navigation.didLaunchApp === true
+      && navigation.termsOfUseAccepted !== packageJSON.version) {
+      return false;
+    }
+
+    return true;
+  }
 );

--- a/src/store/navigation/types.ts
+++ b/src/store/navigation/types.ts
@@ -22,4 +22,5 @@ export type NavigationActionTypes = SetNavigationTab | SetDidLaunchApp;
 export interface NavigationState {
   tab: NavigationTab;
   didLaunchApp: boolean;
+  termsOfUseAccepted: string | false;
 }


### PR DESCRIPTION
Requires new setting under onboardingWizard, for example

```
  onboardingWizard: {
    enabled: true,
    termsOfUseChanged: true,
  },
```

`onboardingWizard` is now blaclisted and can't be changed with DynamicConfig to avoid issues with this feature.