### PR TITLE
issue-1079: Implemented retry-logic for forecasts

### DIFF
--- a/src/network/WeatherApi.ts
+++ b/src/network/WeatherApi.ts
@@ -19,7 +19,8 @@ const isLocationValid = (
 
 export const getForecast = async (
   location: ForecastLocation,
-  country: string
+  country: string,
+  retry: string | false = false
 ): Promise<{forecasts: WeatherData[], isAuroraBorealisLikely: boolean}> => {
   const { language } = i18n;
   const {
@@ -58,6 +59,7 @@ export const getForecast = async (
       'moonPhase',
       'modtime',
       'dark',
+      'producer',
     ],
     ['geoid', 'epochtime'],
   ];
@@ -82,7 +84,8 @@ export const getForecast = async (
 
   const geoMagneticObservationsEnabled = geoMagneticObservations?.countryCodes.includes(country)
                                           && location.latlon !== undefined
-                                          && geoMagneticObservations?.enabled === true;
+                                          && geoMagneticObservations?.enabled === true
+                                          && retry === false;
 
   if (geoMagneticObservationsEnabled && location.latlon) {
     const [lat, lon] = location.latlon.split(',');

--- a/src/store/forecast/actions.ts
+++ b/src/store/forecast/actions.ts
@@ -18,23 +18,22 @@ import {
 
 export const fetchForecast =
   (location: ForecastLocation, filterLocations: number[] = [], country: string) =>
-  (dispatch: Dispatch<ForecastActionTypes>) => {
+  async (dispatch: Dispatch<ForecastActionTypes>) => {
     dispatch({ type: FETCH_FORECAST });
 
-    getForecast(location, country)
-      .then((data) => {
-        const geoid = Number(Object.keys(data)[0]);
-        const favorites = [...filterLocations, geoid];
-        dispatch({
-          type: FETCH_FORECAST_SUCCESS,
-          data,
-          favorites,
-          timestamp: Date.now(),
-        });
-      })
-      .catch((error: Error) => {
-        dispatch({ type: FETCH_FORECAST_ERROR, error, timestamp: Date.now() });
+    try {
+      const data = await getForecast(location, country);
+      const geoid = Number(Object.keys(data)[0]);
+      const favorites = [...filterLocations, geoid];
+      dispatch({
+        type: FETCH_FORECAST_SUCCESS,
+        data,
+        favorites,
+        timestamp: Date.now(),
       });
+    } catch (error) {
+      dispatch({ type: FETCH_FORECAST_ERROR, error: error as Error, timestamp: Date.now() });
+    }
   };
 
 export const updateDisplayParams =

--- a/src/store/forecast/actions.ts
+++ b/src/store/forecast/actions.ts
@@ -1,7 +1,9 @@
 import { Dispatch } from 'redux';
+import moment from 'moment';
 import { getForecast } from '@network/WeatherApi';
 import { ChartType } from '@components/weather/charts/types';
 import { Config } from '@config';
+import { trackMatomoEvent } from '@utils/matomo';
 import {
   Error,
   FETCH_FORECAST,
@@ -14,6 +16,7 @@ import {
   UPDATE_FORECAST_DISPLAY_FORMAT,
   UPDATE_FORECAST_CHART_PARAMETER,
   DisplayParameters,
+  WeatherData,
 } from './types';
 
 export const fetchForecast =
@@ -21,9 +24,34 @@ export const fetchForecast =
   async (dispatch: Dispatch<ForecastActionTypes>) => {
     dispatch({ type: FETCH_FORECAST });
 
+    const MAX_FORECAST_AGE = 24; // hours
+    const { forecast: { data: dataSettings } } = Config.get('weather');
+
     try {
       const data = await getForecast(location, country);
       const geoid = Number(Object.keys(data)[0]);
+
+      let fixedForecasts = [] as WeatherData[];
+
+      // Checks modtime and retry data fetch if data is older than 24 hours
+
+      for (const [index, forecast] of data.forecasts.entries()) {
+        const id = Object.keys(forecast)[0];
+        const modtime = forecast[id][0].modtime;
+        const modtimeMoment = modtime ? moment(modtime+'Z') : undefined;
+
+        if (modtimeMoment && moment().diff(modtimeMoment, 'hours') >= MAX_FORECAST_AGE) {
+          const producer = dataSettings[index].producer;
+          trackMatomoEvent('Error', 'Weather', `Old modtime ${modtime} with producer ${producer} for geoid ${geoid}`);
+          const retryData = await getForecast(location, country, producer);
+          fixedForecasts.push(retryData.forecasts[0]);
+        } else {
+          fixedForecasts.push(forecast);
+        }
+      }
+
+      data.forecasts = fixedForecasts;
+
       const favorites = [...filterLocations, geoid];
       dispatch({
         type: FETCH_FORECAST_SUCCESS,


### PR DESCRIPTION
If forecast data is 24 hours or more old then try to retry with different who-parameter and without If-Modified-Since header (eTag).