### PR TITLE
issue-1040: Enable news only for specific languages

### DIFF
--- a/src/components/news/News.tsx
+++ b/src/components/news/News.tsx
@@ -31,13 +31,13 @@ const News: React.FC<NewsProps> = ({
 }) => {
   const { width} = useWindowDimensions();
   const insets = useSafeAreaInsets();
-  const { t, } = useTranslation('news');
-  const { enabled, numberOfNews } = Config.get('news');
+  const { t, i18n } = useTranslation('news');
+  const { enabled, numberOfNews, apiUrl } = Config.get('news');
   const { dark } = useTheme() as CustomTheme;
   const colorMode = dark ? 'dark' : 'light';
   const isWideDisplay = () => width > 700;
 
-  if (!enabled) {
+  if (!enabled || !apiUrl[i18n.language]) {
     return null;
   }
 

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -201,7 +201,7 @@ interface Feedback {
 
 interface News {
   apiUrl: {
-    [country: string]: string;
+    [language: string]: string;
   };
   numberOfNews: number;
   updateInterval: number;

--- a/src/network/NewsApi.ts
+++ b/src/network/NewsApi.ts
@@ -9,7 +9,7 @@ const getNews = async (language: string): Promise<NewsItem[]> => {
     return Promise.reject(new Error('News API url is not defined'));
   }
 
-  const url = apiUrl[language]+`?limit=${numberOfNews}`;
+  const url = `${apiUrl[language]}${apiUrl[language].includes('?') ? `&limit=${numberOfNews}` : `?limit=${numberOfNews}`}`;
   const { data } = await axiosClient({ url }, undefined, 'News');
 
   const newsItems = data.items.flatMap((item:any):NewsItem | [] => {


### PR DESCRIPTION
Can be done now by defining news apiUrls only for some languages. Also it is possible to define apiURL with filter parameters like `fi: 'https://dev.ilmatieteenlaitos.fi/api/news?tags=filterTagResearch,filterTagWeather'`


