### PR TITLE
issue-1106: Fixed tab bar height for Android < 15

### DIFF
--- a/src/navigators/TabNavigator.tsx
+++ b/src/navigators/TabNavigator.tsx
@@ -509,6 +509,7 @@ const Navigator: React.FC<Props> = ({
               ? darkTheme.colors.tabBarInactive
               : lightTheme.colors.tabBarInactive,
             tabBarLabelStyle: styles.tabText,
+            tabBarStyle: Platform.OS === 'android' && Platform.Version < 35 ? { height: 70 } : {},
             tabBarButton: ({ style, accessibilityState, ...rest }) => {
               const activeColor = useDarkTheme
                 ? darkTheme.colors.tabBarActive


### PR DESCRIPTION
Seems that older versions need fixed height to prevent label text cutting.