### PR TITLE
issue-1141: Added marginBottom for Android

### DIFF
--- a/src/screens/WeatherScreen.tsx
+++ b/src/screens/WeatherScreen.tsx
@@ -246,7 +246,10 @@ const WeatherScreen: React.FC<WeatherScreenProps> = ({
       </View>
     ) : (
     <GradientWrapper>
-      <View testID="weather_view">
+      <View
+        testID="weather_view"
+        style={ Platform.OS === 'android' ? styles.android : null }
+      >
         <ScrollView
           testID="weather_scrollview"
           style={[styles.container]}
@@ -266,6 +269,9 @@ const WeatherScreen: React.FC<WeatherScreenProps> = ({
 const styles = StyleSheet.create({
   container: {
     minHeight: '100%',
+  },
+  android: {
+    marginBottom: 70,
   },
   contentContainer: {
     ...Platform.select({


### PR DESCRIPTION
Android requires margin, because otherwise some content is hidden behind BottomTabBar in legacy UI.