### PR TITLE
issue-1154: CAP warning buttons and texts are ordered by severity

### DIFF
--- a/src/components/warnings/cap/TextList.tsx
+++ b/src/components/warnings/cap/TextList.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from 'react-i18next';
 import { BLACK, GRAYISH_BLUE, CustomTheme } from '@assets/colors';
 import { CapWarning } from '@store/warnings/types';
 import WarningBlock from './WarningBlock';
+import { severityList } from '@store/warnings/constants';
 
 const DateIndicator = ({
   weekDay,
@@ -41,6 +42,7 @@ const TextList = ({
   const { width } = useWindowDimensions();
   const [xOffset, setXOffset] = useState<number>(0);
   const { t } = useTranslation('warnings');
+  const severities = [...severityList].reverse();
 
   const groupAlerts = useCallback((data?: CapWarning[]) => {
     const alerts: { [key: string]: CapWarning[] } = {};
@@ -55,6 +57,17 @@ const TextList = ({
     () => groupAlerts(capData),
     [capData, groupAlerts]
   );
+
+  const sortedGroupNames = useMemo<string[]>(
+    () => severities.flatMap(severity => {
+        return Object.keys(groupedWarnings)?.flatMap((warningGroup) => {
+          const infoMaybeArray = groupedWarnings[warningGroup][0].info;
+          const info = Array.isArray(infoMaybeArray) ? infoMaybeArray[0] : infoMaybeArray;
+          return severity == info.severity ? warningGroup : [];
+      })}),
+    [groupedWarnings, severities]
+  );
+
   return (
     <>
       <View
@@ -76,7 +89,7 @@ const TextList = ({
           ))}
         </ScrollView>
       </View>
-      {Object.keys(groupedWarnings)?.map((warningGroup) => (
+      {sortedGroupNames.map((warningGroup) => (
         <WarningBlock
           dates={dates}
           warnings={groupedWarnings[warningGroup]}

--- a/src/components/warnings/cap/WarningTypeFiltersList.tsx
+++ b/src/components/warnings/cap/WarningTypeFiltersList.tsx
@@ -5,6 +5,7 @@ import { CustomTheme, SECONDARY_BLUE } from '@assets/colors';
 import React from 'react';
 import { View, ScrollView, StyleSheet } from 'react-native';
 import WarningSymbol from '../WarningsSymbol';
+import { severityList } from '@store/warnings/constants';
 
 const WarningTypeFiltersList = ({
   warnings,
@@ -16,15 +17,16 @@ const WarningTypeFiltersList = ({
   activeWarnings: { severity: Severity; event: string }[];
 }) => {
   const { colors } = useTheme() as CustomTheme;
+  const severities = [...severityList].reverse();
   return (
     <ScrollView
       style={styles.row}
       horizontal
       showsHorizontalScrollIndicator={false}>
-      {warnings?.slice(0).map((warning) => {
+      { severities.map(severity => warnings?.slice(0).map((warning) => {
         const info = Array.isArray(warning.info) ? warning.info[0] : warning.info;
 
-        return (
+        return severity === info.severity ? (
           <AccessibleTouchableOpacity
             key={`${info.event}-${info.severity}`}
             onPress={() => onWarningTypePress(warning)}>
@@ -37,8 +39,8 @@ const WarningTypeFiltersList = ({
                   borderColor: colors.background,
                 },
                 !activeWarnings.find(
-                  ({ severity, event }) =>
-                    info.severity === severity &&
+                  ({ severity: activeSeverity, event }) =>
+                    info.severity === activeSeverity &&
                     info.event === event
                 ) && styles.activeFilter,
               ]}>
@@ -48,8 +50,8 @@ const WarningTypeFiltersList = ({
               />
             </View>
           </AccessibleTouchableOpacity>
-        )
-      })}
+        ) : null
+      }))}
     </ScrollView>
   );
 };

--- a/src/screens/WeatherScreen.tsx
+++ b/src/screens/WeatherScreen.tsx
@@ -248,7 +248,10 @@ const WeatherScreen: React.FC<WeatherScreenProps> = ({
     <GradientWrapper>
       <View
         testID="weather_view"
-        style={ Platform.OS === 'android' ? styles.android : null }
+        style={
+          Platform.OS === 'android' && weatherConfig.layout !== 'legacyWithoutBackgroundColor'
+            ? styles.legacyAndroid : null
+        }
       >
         <ScrollView
           testID="weather_scrollview"
@@ -270,7 +273,7 @@ const styles = StyleSheet.create({
   container: {
     minHeight: '100%',
   },
-  android: {
+  legacyAndroid: {
     marginBottom: 70,
   },
   contentContainer: {


### PR DESCRIPTION
Also UI fix for Android when `legacyWithoutBackgroundColor` layout is used.