### PR TITLE
issue-1181: Fixed issue that yellow box error could be persistent on the first startup

### DIFF
--- a/src/components/common/ErrorComponent.tsx
+++ b/src/components/common/ErrorComponent.tsx
@@ -93,7 +93,7 @@ const ErrorComponent: React.FC<ErrorProps> = ({
       geoid,
       latlon: `${location.lat},${location.lon}`
     }
-    fetchForecast(forecastLocation, [geoid], location.country);
+    fetchForecast(forecastLocation, location.country);
   }, [fetchForecast, location]);
 
   const tryUpdateObservation = useCallback(() => {

--- a/src/screens/WeatherScreen.tsx
+++ b/src/screens/WeatherScreen.tsx
@@ -90,7 +90,7 @@ const WeatherScreen: React.FC<WeatherScreenProps> = ({
       latlon: `${location.lat},${location.lon}`
     }
 
-    fetchForecast(forecastLocation, geoid ? [geoid] : [], location.country);
+    fetchForecast(forecastLocation, location.country);
     setForecastUpdated(Date.now());
   }, [
     fetchForecast,

--- a/src/store/forecast/actions.ts
+++ b/src/store/forecast/actions.ts
@@ -20,7 +20,7 @@ import {
 } from './types';
 
 export const fetchForecast =
-  (location: ForecastLocation, filterLocations: number[] = [], country: string) =>
+  (location: ForecastLocation, country: string) =>
   async (dispatch: Dispatch<ForecastActionTypes>) => {
     dispatch({ type: FETCH_FORECAST });
 
@@ -29,8 +29,6 @@ export const fetchForecast =
 
     try {
       const data = await getForecast(location, country);
-      const geoid = Number(Object.keys(data)[0]);
-
       let fixedForecasts = [] as WeatherData[];
 
       // Checks modtime and retry data fetch if data is older than 24 hours
@@ -54,11 +52,9 @@ export const fetchForecast =
 
       data.forecasts = fixedForecasts;
 
-      const favorites = [...filterLocations, geoid];
       dispatch({
         type: FETCH_FORECAST_SUCCESS,
         data,
-        favorites,
         timestamp: Date.now(),
       });
     } catch (error) {

--- a/src/store/forecast/reducer.ts
+++ b/src/store/forecast/reducer.ts
@@ -18,7 +18,7 @@ import constants from './constants';
 const INITIAL_STATE: ForecastState = {
   data: {},
   auroraBorealisData: {},
-  loading: false,
+  loading: true,
   error: false,
   displayParams: [],
   displayFormat: 'table',
@@ -53,14 +53,12 @@ const formatData = (dataSets: WeatherData[]): WeatherData => {
   return weatherData;
 };
 
-const filterLocations = (data: WeatherData, favorites: number[]): WeatherData =>
-  Object.keys(data)
-    .map((geoid) => (geoid === 'nan' ? 0 : Number(geoid)))
-    .filter((geoid) => favorites.includes(Number(geoid)))
-    .reduce(
-      (obj, key) => ({ ...obj, [key]: data[key === 0 ? 'nan' : key] }),
-      {}
-    );
+const fixLocationsWithoutGeoId = (data: WeatherData): WeatherData =>
+  Object.keys(data).reduce((result, key) => {
+    const normalizedKey = key === 'nan' ? '0' : key;
+    result[normalizedKey] = data[key];
+    return result;
+  }, {} as WeatherData);
 
 export default (
   // eslint-disable-next-line @typescript-eslint/default-param-last
@@ -82,9 +80,8 @@ export default (
           ? Object.keys(action.data.forecasts[0])[0] : 0;
       return {
         ...state,
-        data: filterLocations(
+        data: fixLocationsWithoutGeoId(
           { ...state.data, ...formatData(action.data.forecasts) },
-          action.favorites
         ),
         auroraBorealisData: {
           ...state.auroraBorealisData,

--- a/src/store/forecast/types.ts
+++ b/src/store/forecast/types.ts
@@ -27,7 +27,6 @@ interface FetchForecastSuccess {
     forecasts: WeatherData[],
     isAuroraBorealisLikely: boolean
   };
-  favorites: number[];
   timestamp: number;
 }
 


### PR DESCRIPTION
There is usually race condition between the default location and user location (if location has been enabled) on the first startup. It is not guaranteed that loading the data for default location finishes earlier than loading data for user location even getting user location takes some time. And there was issue that `filterLocations()` cleared data for all other locations than current. So it could happen that when data for default location was got it cleared data for user location that was currently selected causing persistent yellow box error.

Changes:

- Set initial loading state for forecasts to `true` -> prevents showing yellow box initially
- Renamed `filterLocations()` to `fixLocationsWithoutGeoId()` and removed clearing any data, it just changes locations with `nan` geoid to 0 geoid

Yellow box may still flash shortly, but it should not stay permanently if data loading is successful.