### PR TITLE
issue-924: 6h tick interval for forecast graphs if 12-hour clock

### DIFF
--- a/src/components/weather/charts/Chart.tsx
+++ b/src/components/weather/charts/Chart.tsx
@@ -278,6 +278,7 @@ const Chart: React.FC<ChartProps> = ({
             clockType={clockType}
             isDaily={isDaily}
             units={units}
+            observation={observation}
           />
         </ScrollView>
         <ChartYAxis

--- a/src/components/weather/charts/ChartDataRenderer.tsx
+++ b/src/components/weather/charts/ChartDataRenderer.tsx
@@ -21,6 +21,7 @@ type ChartDataRendererProps = {
   clockType: ClockType;
   isDaily: boolean;
   units?: UnitMap;
+  observation?: boolean;
 };
 const ChartDataRenderer: React.FC<ChartDataRendererProps> = ({
   chartDimensions,
@@ -33,6 +34,7 @@ const ChartDataRenderer: React.FC<ChartDataRendererProps> = ({
   clockType,
   isDaily,
   units,
+  observation,
 }) => {
   const { fontScale } = useWindowDimensions()
   const { colors } = useTheme() as CustomTheme;
@@ -54,7 +56,7 @@ const ChartDataRenderer: React.FC<ChartDataRendererProps> = ({
   const tickLabels = tickValues.map((value, index, arr) => {
     // Hide first and last tick label from daily chart
     if (isDaily && (index === 0 || index === arr.length - 1)) return '';
-    return tickFormat(value, locale, clockType, isDaily);
+    return tickFormat(value, locale, clockType, isDaily, observation);
   });
 
   return (

--- a/src/utils/chart.ts
+++ b/src/utils/chart.ts
@@ -161,18 +161,23 @@ export const tickFormat = (
   tick: any,
   locale: string,
   clockType: ClockType,
-  daily?: boolean
+  daily?: boolean,
+  observation = false,
 ): string | number => {
   const time = moment(tick);
   const hour = time.hour();
   const minutes = time.minutes();
+  const divider = clockType === 12 && !observation ? 6 : 3;
 
-  if (!daily && (hour % 3 !== 0 || minutes !== 0)) {
+  if (!daily && (hour % divider !== 0 || minutes !== 0)) {
     return '';
   }
   if (daily || hour === 0) {
-    return `${capitalize(time.format(locale === 'en' ? 'ddd' : 'dd'))}
-${time.format(locale === 'en' ? 'D MMM' : 'D.M.')}`;
+    return `${capitalize(
+      time.format(locale === 'en' ? 'ddd' : 'dd')
+    )}\n${time.format(
+      locale === 'en' ? 'D MMM' : 'D.M.'
+    )}`;
   }
   return time.format(clockType === 12 ? 'h a' : 'HH');
 };


### PR DESCRIPTION
Kept 3h tick interval in observation graphs because there is enough space. Also some code clean up for daily ticks.

Closes #924 