### PR TITLE
issue-983: Layout fixes for small iOS widgets

### DIFF
--- a/ios/Widget/ForecastWidget.swift
+++ b/ios/Widget/ForecastWidget.swift
@@ -211,8 +211,8 @@ struct SmallWidgetView : View {
       ForecastErrorView(error: entry.error!, size: .small)
     } else {
       VStack(spacing: 0) {
-        Text(entry.formatLocation()).style(.boldLocation).padding(.top, 8)
-        Text(entry.formatArea()).style(.location)
+        Text(entry.location.name).style(.boldLocation)
+        Text(entry.location.area).style(.location)
         Spacer()
         NextHourForecast(timeStep: entry.timeSteps[0])
         Spacer()

--- a/ios/Widget/WarningsTodayWidget.swift
+++ b/ios/Widget/WarningsTodayWidget.swift
@@ -193,7 +193,7 @@ struct SmallWarningsTodayView : View {
         .modifier(TextModifier())
     } else {
       VStack {
-        Text("**\(entry.location.name),**").style(.location)
+        Text(entry.location.name).style(.boldLocation)
         Text(entry.location.area).style(.location)
         if (entry.warnings.isEmpty) {
           Spacer()


### PR DESCRIPTION
Fixed alignment in small forecast widget, removed comma after location name and unified code to present location name in both small widgets.

Closes #983 