### PR TITLE
issue-1244: Added hideLongAreaList option to capViewSettings

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -640,7 +640,8 @@
       "warningExplanationsAtSea": "Explanations of warnings for sea areas",
       "warningColorsExplanation": "Explanations of warning colors",
       "timezone": "Time zone",
-      "timezoneText": "All times on the application are displayed according to the selected time zone."
+      "timezoneText": "All times on the application are displayed according to the selected time zone.",
+      "areas": "{{ count }} municipalities"
     }
   },
   "setUp": {

--- a/i18n/fi.json
+++ b/i18n/fi.json
@@ -640,7 +640,8 @@
       "warningExplanationsAtSea": "Varoitusten selitykset merialueilla",
       "warningColorsExplanation": "Varoitusvärien selitykset",
       "timezone": "Aikavyöhyke",
-      "timezoneText": "Kaikki sovelluksen kellonajat esitetään valitun aikavyöhykkeen sijainnin ajan mukaan."
+      "timezoneText": "Kaikki sovelluksen kellonajat esitetään valitun aikavyöhykkeen sijainnin ajan mukaan.",
+      "areas": "{{ count }} kunnassa"
     }
   },
   "setUp": {

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -640,7 +640,8 @@
       "warningExplanationsAtSea": "Förklaringar till varningarna för havsområden",
       "warningColorsExplanation": "Förklaringar till varningsfärger",
       "timezone": "Tidszon",
-      "timezoneText": "Alla klockslag för applikationen anges enligt den valda tidszonens placering."
+      "timezoneText": "Alla klockslag för applikationen anges enligt den valda tidszonens placering.",
+      "areas": "{{ count }} kommuner"
     }
   },
   "setUp": {

--- a/src/components/warnings/cap/WarningBlock.tsx
+++ b/src/components/warnings/cap/WarningBlock.tsx
@@ -30,6 +30,8 @@ const mapStateToProps = (state: State) => ({
 
 const connector = connect(mapStateToProps);
 
+const MAX_AREA_COUNT_FOR_HIDE_LONG_AREA_LIST = 5;
+
 const WarningItem = ({
   areasDescription,
   warning,
@@ -56,13 +58,16 @@ const WarningItem = ({
   showDescription?: boolean;
 }) => {
   const { capViewSettings } = Config.get('warnings');
-  const { i18n } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { colors } = useTheme() as CustomTheme;
   const info = Array.isArray(warning.info) ? selectCapInfoByLanguage(warning.info, i18n.language): warning.info;
   const areaDesc = info.area.areaDesc
     .charAt(0)
     .toUpperCase()
     .concat(info.area.areaDesc.substring(1));
+
+  const areaList = areasDescription || areaDesc;
+  const areaCount = areaList.split(',').length;
 
   return (
     <View>
@@ -105,7 +110,12 @@ const WarningItem = ({
             {timespan}
           </Text>
           <Text style={[styles.headingText, { color: colors.hourListText}] }>
-            {areasDescription || areaDesc}
+            {
+              capViewSettings?.hideLongArealist && areaCount > MAX_AREA_COUNT_FOR_HIDE_LONG_AREA_LIST ?
+                t('warnings:capInfo:areas', { count: areaCount })
+              :
+                areaList
+            }
           </Text>
         </View>
         {includeArrow && (
@@ -134,12 +144,12 @@ function WarningBlock({
   dates,
   warnings,
   xOffset,
-}: {
+}: Readonly<{
   clockType: ClockType;
   dates: { time: number; date: string; weekday: string }[];
   warnings: CapWarning[];
   xOffset?: number;
-}) {
+}>) {
   const [open, setOpen] = useState(false);
   const { colors } = useTheme() as CustomTheme;
   const scrollViewRef = useRef<ScrollView>(null);

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -120,6 +120,7 @@ interface CapViewSettings {
   warningBlockWarningCountEnabled?: boolean;
   includeAreaInTitle?: boolean;
   severityBackgroundInSymbol?: boolean;
+  hideLongArealist?: boolean;
 }
 
 interface Warnings {

--- a/src/network/CapWarningsApi.ts
+++ b/src/network/CapWarningsApi.ts
@@ -44,14 +44,14 @@ const getCapWarnings = async () => {
   const { feed } = parser.parse(feedData);
   const entriesList = Array.isArray(feed.entry) ? feed.entry : [feed.entry];
 
-  const urls : [string] = entriesList.map((entry: { link: [{ '@_href': string, '@_type': string | undefined }] }) => {
+  const urls: string[] = entriesList.map((entry: { link: Array<{ '@_href': string; '@_type'?: string }> } | { link: { '@_href': string; '@_type'?: string } }) => {
     if (Array.isArray(entry.link)) {
       // Meteoalarm feed may contain multiple links
       const links = entry.link.filter((link) => link['@_type'] && link['@_type'] === CAP_MIME_TYPE);
-      return links[0]['@_href'];
+      return links[0]['@_href'].replace('http://', 'https://');
     } else {
       // Smartmet feed contains only one link
-      return entry.link['@_href'];
+      return (entry.link['@_href'] as string).replace('http://', 'https://');
     }
   });
   const uniqueUrls = [...new Set(urls)];


### PR DESCRIPTION
When enabled shows number of municipalities where warning is active instead of long area list. Also added conversion of http-protocol to https in CAP links.

Closes #1244 