### PR TITLE
issue-1255: Added support for relative day names in CAP warnings

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -600,6 +600,9 @@
     "lessAccessibilityHint": "hide detailed warning description",
     "infoAccessibilityLabel": "warnings info",
     "loadingError": "Failed to load local warnings.",
+    "today": "Today",
+    "tomorrow": "Tomorrow",
+    "dayAfterTomorrow": "In 2 days",
     "types": {
       "thunderstorm": "Severe thunderstorm",
       "wind": "Wind warning for land areas",

--- a/i18n/fi.json
+++ b/i18n/fi.json
@@ -600,6 +600,9 @@
     "lessAccessibilityHint": "piilota varoituksen tarkemmat tiedot",
     "infoAccessibilityLabel": "varoitusten selitteet",
     "loadingError": "Paikkakuntakohtaisten varoitusten lataaminen epäonnistui.",
+    "today": "Tänään",
+    "tomorrow": "Huomenna",
+    "dayAfterTomorrow": "Ylihuomenna",
     "types": {
       "thunderstorm": "Raju ukonilma",
       "wind": "Tuulivaroitus maa-alueille",

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -600,6 +600,9 @@
     "lessAccessibilityHint": "dölja närmare uppgifter om varningen",
     "infoAccessibilityLabel": "Varningar förklaringar",
     "loadingError": "Misslyckades att ladda platsbaserade varningar.",
+    "today": "Idag",
+    "tomorrow": "Imorgon",
+    "dayAfterTomorrow": "I övermorgon",
     "types": {
       "thunderstorm": "Varning för våldsamt åskväder",
       "wind": "Vindvarning för landområden",

--- a/ios/MobileWeather.xcodeproj/project.pbxproj
+++ b/ios/MobileWeather.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 70;
+	objectVersion = 60;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -155,14 +155,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		A21766F22CFF4F99001EEEFF /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		A21766F22CFF4F99001EEEFF /* Exceptions for "SettingsIntentExtension" folder in "WidgetExtension" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
 			);
 			target = A2B3FF952CC7D1DA00EC1293 /* WidgetExtension */;
 		};
-		A2E441DA2CFF50AB00802217 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+		A2E441DA2CFF50AB00802217 /* Exceptions for "SettingsIntentExtension" folder in "SettingsIntentExtension" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
@@ -172,9 +172,41 @@
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
-		A2042C6F2CFF2EEF00C41A9E /* SettingsIntentExtension */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (A21766F22CFF4F99001EEEFF /* PBXFileSystemSynchronizedBuildFileExceptionSet */, A2E441DA2CFF50AB00802217 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = SettingsIntentExtension; sourceTree = "<group>"; };
-		A286CB982CF49C2900812898 /* managers */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = managers; sourceTree = "<group>"; };
-		A299E3022CDB746F003502F5 /* views */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = views; sourceTree = "<group>"; };
+		A2042C6F2CFF2EEF00C41A9E /* SettingsIntentExtension */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				A21766F22CFF4F99001EEEFF /* Exceptions for "SettingsIntentExtension" folder in "WidgetExtension" target */,
+				A2E441DA2CFF50AB00802217 /* Exceptions for "SettingsIntentExtension" folder in "SettingsIntentExtension" target */,
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = SettingsIntentExtension;
+			sourceTree = "<group>";
+		};
+		A286CB982CF49C2900812898 /* managers */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = managers;
+			sourceTree = "<group>";
+		};
+		A299E3022CDB746F003502F5 /* views */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+			);
+			explicitFileTypes = {
+			};
+			explicitFolders = (
+			);
+			path = views;
+			sourceTree = "<group>";
+		};
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */

--- a/src/components/warnings/cap/CapWarningsView.tsx
+++ b/src/components/warnings/cap/CapWarningsView.tsx
@@ -65,17 +65,24 @@ const CapWarningsView: React.FC<CapWarningsViewProps> = ({
         time: today.toDate().getTime(),
         date: moment(today).locale(locale).format(dateFormat),
         weekday: moment(today).locale(locale).format(weekdayAbbreviationFormat),
+        relativeDay: t('today'),
       },
     ];
     if (capViewSettings) {
       for (let i = 1; i < capViewSettings?.numberOfDays; i += 1) {
         const momentObject = moment(today).add(i, 'days');
+        let relativeDay = '';
+
+        if (i === 1) relativeDay = t('tomorrow');
+        if (i === 2) relativeDay = t('dayAfterTomorrow');
+
         dates.push({
           time: momentObject.toDate().getTime(),
           date: momentObject.locale(locale).format(dateFormat),
           weekday: momentObject
             .locale(locale)
             .format(weekdayAbbreviationFormat),
+          relativeDay,
         });
       }
     }

--- a/src/components/warnings/cap/DaySelectorList.tsx
+++ b/src/components/warnings/cap/DaySelectorList.tsx
@@ -4,6 +4,7 @@ import { useTheme } from '@react-navigation/native';
 import { CustomTheme, GRAYISH_BLUE } from '@assets/colors';
 import AccessibleTouchableOpacity from '@components/common/AccessibleTouchableOpacity';
 import CapSeverityBar from './CapSeverityBar';
+import { Config } from '@config';
 
 const DaySelector = ({
   active,
@@ -11,6 +12,7 @@ const DaySelector = ({
   index,
   severities,
   weekday,
+  relativeDay,
   date,
   last,
 }: {
@@ -19,10 +21,14 @@ const DaySelector = ({
   index: number;
   severities?: number[];
   weekday: string;
+  relativeDay: string;
   date: string;
   last?: boolean;
 }) => {
+  const { capViewSettings } = Config.get('warnings');
   const { colors } = useTheme() as CustomTheme;
+  const width = capViewSettings?.useRelativeDays ? 110 : 70;
+
   return (
     <AccessibleTouchableOpacity
       onPress={() => onSelect(index)}
@@ -38,6 +44,7 @@ const DaySelector = ({
             backgroundColor: active
               ? colors.screenBackground
               : colors.background,
+            width,
           },
         ]}>
         <Text
@@ -46,7 +53,7 @@ const DaySelector = ({
             styles.capitalized,
             { color: colors.primaryText },
           ]}>
-          {weekday}
+          {capViewSettings?.useRelativeDays ? relativeDay : weekday}
         </Text>
         <Text style={[styles.text, { color: colors.primaryText }]}>{date}</Text>
         <View style={styles.severityBarContainer}>
@@ -64,7 +71,7 @@ const DaySelectorList = ({
   onDayChange,
 }: {
   activeDay: number;
-  dates: { weekday: string; date: string; time: number }[];
+  dates: { weekday: string; date: string; time: number, relativeDay: string }[];
   dailySeverities: number[][];
   onDayChange: (arg0: number) => void;
 }) => (
@@ -73,11 +80,12 @@ const DaySelectorList = ({
     horizontal
     showsHorizontalScrollIndicator={false}>
     <View style={styles.row}>
-      {dates.map(({ time, weekday, date }, index) => (
+      {dates.map(({ time, weekday, date, relativeDay }, index) => (
         <DaySelector
           active={activeDay === index}
           key={time}
           weekday={weekday}
+          relativeDay={relativeDay}
           date={date}
           onSelect={() => onDayChange(index)}
           severities={dailySeverities[index]}

--- a/src/components/warnings/cap/MapView.tsx
+++ b/src/components/warnings/cap/MapView.tsx
@@ -38,7 +38,7 @@ const connector = connect(mapStateToProps);
 type PropsFromRedux = ConnectedProps<typeof connector>;
 
 type MapViewProps = PropsFromRedux & {
-  dates: { time: number; weekday: string; date: string }[];
+  dates: { time: number; weekday: string; date: string, relativeDay: string }[];
   capData?: CapWarning[];
 };
 

--- a/src/components/warnings/cap/TextList.tsx
+++ b/src/components/warnings/cap/TextList.tsx
@@ -12,19 +12,24 @@ import { BLACK, GRAYISH_BLUE, CustomTheme } from '@assets/colors';
 import { CapWarning } from '@store/warnings/types';
 import WarningBlock from './WarningBlock';
 import { severityList } from '@store/warnings/constants';
+import { Config } from '@config';
 
 const DateIndicator = ({
   weekDay,
   date,
+  relativeDay,
 }: {
   weekDay: string;
   date: string;
+  relativeDay: string;
 }) => {
+  const { capViewSettings } = Config.get('warnings');
   const { colors } = useTheme() as CustomTheme;
+  const width = capViewSettings?.useRelativeDays ? null : 45;
   return (
-    <View style={styles.dateIndicatorEntry}>
+    <View style={[styles.dateIndicatorEntry, { width }]}>
       <Text style={[styles.capitalized, { color: colors.hourListText }]}>
-        {weekDay}
+        {capViewSettings?.useRelativeDays ? relativeDay : weekDay}
       </Text>
       <Text style={{ color: colors.hourListText }}>{date}</Text>
     </View>
@@ -36,7 +41,7 @@ const TextList = ({
   dates,
 }: {
   capData?: CapWarning[];
-  dates: { time: number; date: string; weekday: string }[];
+  dates: { time: number; date: string; weekday: string, relativeDay: string }[];
 }) => {
   const { colors } = useTheme() as CustomTheme;
   const { width } = useWindowDimensions();
@@ -80,11 +85,12 @@ const TextList = ({
           showsHorizontalScrollIndicator={false}
           style={[styles.dateIndicatorRow, { width: width - 136 }]}
           onScroll={(e) => setXOffset(e.nativeEvent.contentOffset.x)}>
-          {dates.map(({ time, weekday, date }) => (
+          {dates.map(({ time, weekday, date, relativeDay }) => (
             <DateIndicator
               key={`indicator-${time}`}
               weekDay={weekday}
               date={date}
+              relativeDay={relativeDay}
             />
           ))}
         </ScrollView>
@@ -133,7 +139,6 @@ const styles = StyleSheet.create({
     flexDirection: 'column',
     alignItems: 'center',
     marginRight: 7,
-    width: 45,
   },
   noActiveWarningsPanel: {
     display: 'flex',

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -121,6 +121,7 @@ interface CapViewSettings {
   includeAreaInTitle?: boolean;
   severityBackgroundInSymbol?: boolean;
   hideLongArealist?: boolean;
+  useRelativeDays?: boolean;
 }
 
 interface Warnings {


### PR DESCRIPTION
Added support to use relative day names in CAP warnings if `useRelativeDays` setting is enabled.

In english there is "In 2 days" translation because "Day After Tomorrow" was too long to fit.

Also fixed `objectVersion = 60;` for iOS, because it was accidentally changed in widget refactoring.

Closes #1255