### PR TITLE
issue-1269: Android hourly forecast layout issue

### DIFF
--- a/__tests__/components/ModalForecast.test.tsx
+++ b/__tests__/components/ModalForecast.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render } from '@testing-library/react-native';
+import { act, fireEvent, render } from '@testing-library/react-native';
 
 import ModalForecast from '../../src/components/weather/forecast/ModalForecast';
 import * as constants from '../../src/store/forecast/constants';
@@ -174,6 +174,7 @@ const makeData = (count: number, startHour = 0) =>
 
 describe('ModalForecast', () => {
   beforeEach(() => {
+    jest.useFakeTimers();
     mockForecastListColumn.mockClear();
     mockForecastListHeaderColumn.mockClear();
     mockScrollToIndex.mockClear();
@@ -184,6 +185,10 @@ describe('ModalForecast', () => {
       fontScale: 1,
       scale: 1,
     };
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   it('returns null without data', () => {
@@ -233,6 +238,11 @@ describe('ModalForecast', () => {
         modal: true,
       })
     );
+
+    act(() => {
+      jest.advanceTimersByTime(50);
+    });
+
     expect(mockScrollToIndex).toHaveBeenCalledWith({
       animated: false,
       index: 0,
@@ -251,6 +261,10 @@ describe('ModalForecast', () => {
       />
     );
 
+    act(() => {
+      jest.advanceTimersByTime(50);
+    });
+
     expect(mockScrollToIndex).toHaveBeenCalledWith({
       animated: false,
       index: 3,
@@ -268,6 +282,11 @@ describe('ModalForecast', () => {
         initialPosition="start"
       />
     );
+
+    act(() => {
+      jest.advanceTimersByTime(50);
+    });
+    mockScrollToIndex.mockClear();
 
     fireEvent.scroll(view.getByTestId('flat-list'), {
       nativeEvent: {

--- a/src/components/weather/forecast/ForecastListColumn.tsx
+++ b/src/components/weather/forecast/ForecastListColumn.tsx
@@ -44,6 +44,7 @@ const ForecastListColumn: React.FC<ForecastListColumnProps> = ({
   const activeParameters = Config.get('weather').forecast.data.flatMap(
     ({ parameters }) => parameters
   );
+  const defaultUnits = Config.get('settings').units;
 
   const time = moment
     .unix(data.epochtime)
@@ -109,8 +110,7 @@ const ForecastListColumn: React.FC<ForecastListColumnProps> = ({
             );
           }
           if (param === constants.WIND_SPEED_AND_DIRECTION) {
-            const windSpeedUnit =
-              units?.wind.unitAbb ?? Config.get('settings').units.wind;
+            const windSpeedUnit = units?.wind.unitAbb ?? defaultUnits.wind;
             const convertedWindSpeed =
               data.windSpeedMS || data.windSpeedMS === 0
                 ? toPrecision(
@@ -172,9 +172,7 @@ const ForecastListColumn: React.FC<ForecastListColumnProps> = ({
             );
           }
           if (param === constants.TEMPERATURE) {
-            const temperatureUnit =
-              units?.temperature.unitAbb ??
-              Config.get('settings').units.temperature;
+            const temperatureUnit = units?.temperature.unitAbb ?? defaultUnits.temperature;
             const convertedTemperature =
               data.temperature || data.temperature === 0
                 ? toPrecision(
@@ -210,9 +208,7 @@ const ForecastListColumn: React.FC<ForecastListColumnProps> = ({
             );
           }
           if (param === constants.FEELS_LIKE) {
-            const temperatureUnit =
-              units?.temperature.unitAbb ??
-              Config.get('settings').units.temperature;
+            const temperatureUnit = units?.temperature.unitAbb ?? defaultUnits.temperature;
             const convertedFeelsLike =
               data.feelsLike || data.feelsLike === 0
                 ? toPrecision(
@@ -250,9 +246,7 @@ const ForecastListColumn: React.FC<ForecastListColumnProps> = ({
           }
 
           if (param === constants.DEW_POINT) {
-            const temperatureUnit =
-              units?.temperature.unitAbb ??
-              Config.get('settings').units.temperature;
+            const temperatureUnit = units?.temperature.unitAbb ?? defaultUnits.temperature;
             const convertedDewPoint =
               data.dewPoint || data.dewPoint === 0
                 ? toPrecision(
@@ -321,7 +315,6 @@ const ForecastListColumn: React.FC<ForecastListColumnProps> = ({
             );
           }
 
-          const defaultUnits = Config.get('settings').units;
           const precipitationUnit =
             units?.precipitation.unitAbb ?? defaultUnits.precipitation;
           const precipitationPrecision =

--- a/src/components/weather/forecast/ModalForecast.tsx
+++ b/src/components/weather/forecast/ModalForecast.tsx
@@ -71,18 +71,22 @@ const ModalForecast: React.FC<ModalForecastProps> = ({
 
     if (initialPosition === 'start') {
       setCurrentIndex(0);
-      flatListRef.current?.scrollToIndex({
-        animated: false,
-        index: 0,
-        viewPosition: 0,
-      });
+      setTimeout(() => {
+        flatListRef.current?.scrollToIndex({
+          animated: false,
+          index: 0,
+          viewPosition: 0,
+        });
+      }, 50);
     } else {
       setCurrentIndex(data.length - 1);
-      flatListRef.current?.scrollToIndex({
-        animated: false,
-        index: data.length - 1,
-        viewPosition: 0,
-      });
+      setTimeout(() => {
+        flatListRef.current?.scrollToIndex({
+          animated: false,
+          index: data.length - 1,
+          viewPosition: 0,
+        });
+      }, 50);
     }
   }, [data, initialPosition]);
 


### PR DESCRIPTION
Added small timeout before scroll to correct position so that Android has time to render layout. This also caused changes to tests.

Also made a small code improvement to `ForecastListColumn` component to avoid calling `Config.get('settings').units;` in loop.

Closes #1269 