### PR TITLE
issue-1270: Fixed hourly forecast close button issues

### DIFF
--- a/__tests__/components/ModalContent.test.tsx
+++ b/__tests__/components/ModalContent.test.tsx
@@ -74,8 +74,20 @@ jest.mock('@components/common/CloseButton', () => ({
 
 jest.mock('../../src/components/weather/forecast/ModalForecast', () => ({
   __esModule: true,
-  default: ({ data, initialPosition }: any) => {
-    mockModalForecast({ data, initialPosition });
+  default: ({
+    data,
+    initialPosition,
+    maxHeight,
+    onScrollOffsetChange,
+    onScrollOffsetMaxChange,
+  }: any) => {
+    mockModalForecast({
+      data,
+      initialPosition,
+      maxHeight,
+      onScrollOffsetChange,
+      onScrollOffsetMaxChange,
+    });
     const { Text } = require('react-native');
     return <Text testID="modal-forecast">{`${data.length}-${initialPosition}`}</Text>;
   },
@@ -128,6 +140,9 @@ describe('ModalContent', () => {
     expect(mockModalForecast).toHaveBeenCalledWith({
       data: [{ epochtime: 1 }],
       initialPosition: 'start',
+      maxHeight: undefined,
+      onScrollOffsetChange: undefined,
+      onScrollOffsetMaxChange: undefined,
     });
     expect(getByTestId('modal-forecast')).toBeTruthy();
   });
@@ -151,6 +166,9 @@ describe('ModalContent', () => {
     expect(mockModalForecast).toHaveBeenCalledWith({
       data: [{ epochtime: 1 }],
       initialPosition: 'end',
+      maxHeight: undefined,
+      onScrollOffsetChange: undefined,
+      onScrollOffsetMaxChange: undefined,
     });
   });
 
@@ -172,6 +190,9 @@ describe('ModalContent', () => {
     expect(mockModalForecast).toHaveBeenCalledWith({
       data: [],
       initialPosition: 'start',
+      maxHeight: undefined,
+      onScrollOffsetChange: undefined,
+      onScrollOffsetMaxChange: undefined,
     });
   });
 });

--- a/__tests__/components/Vertical10DaysForecast.test.tsx
+++ b/__tests__/components/Vertical10DaysForecast.test.tsx
@@ -43,6 +43,15 @@ jest.mock('@react-navigation/native', () => ({
   }),
 }));
 
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+  }),
+}));
+
 jest.mock('@assets/images', () => ({
   weatherSymbolGetter: (symbol: string) => {
     const { Text } = require('react-native');

--- a/src/components/weather/forecast/ModalContent.tsx
+++ b/src/components/weather/forecast/ModalContent.tsx
@@ -29,6 +29,9 @@ type ModalContentProps = PropsFromRedux & {
   onClose: () => void;
   onDayChange: (forward: boolean) => void;
   initialPosition: 'start' | 'end';
+  modalMaxHeight?: number;
+  onScrollOffsetChange?: (offset: number) => void;
+  onScrollOffsetMaxChange?: (offset: number) => void;
 };
 
 const DailyModal: React.FC<ModalContentProps> = ({
@@ -37,7 +40,10 @@ const DailyModal: React.FC<ModalContentProps> = ({
   timeStamp,
   onClose,
   onDayChange,
-  initialPosition
+  initialPosition,
+  modalMaxHeight,
+  onScrollOffsetChange,
+  onScrollOffsetMaxChange,
 }) => {
   const { fontScale } = useWindowDimensions();
   const { t, i18n } = useTranslation('forecast');
@@ -100,6 +106,9 @@ const DailyModal: React.FC<ModalContentProps> = ({
       <ModalForecast
         data={data ? data[moment(timeStamp).format('D.M.')] : []}
         initialPosition={initialPosition}
+        maxHeight={modalMaxHeight}
+        onScrollOffsetChange={onScrollOffsetChange}
+        onScrollOffsetMaxChange={onScrollOffsetMaxChange}
       />
     </View>
   );

--- a/src/components/weather/forecast/ModalForecast.tsx
+++ b/src/components/weather/forecast/ModalForecast.tsx
@@ -29,7 +29,6 @@ import ForecastListColumn from './ForecastListColumn';
 import ForecastListHeaderColumn from './ForecastListHeaderColumn';
 
 import TimeSelectButtonGroup from './TimeSelectButtonGroup';
-import { MAX_PARAMETERS_WITHOUT_SCROLL } from './constants';
 // import { trackMatomoEvent } from '@utils/matomo';
 
 const mapStateToProps = (state: State) => ({
@@ -45,6 +44,9 @@ type PropsFromRedux = ConnectedProps<typeof connector>;
 type ModalForecastProps = PropsFromRedux & {
   data: TimeStepData[];
   initialPosition?: 'start' | 'end';
+  maxHeight?: number;
+  onScrollOffsetChange?: (offset: number) => void;
+  onScrollOffsetMaxChange?: (offset: number) => void;
 };
 
 const ModalForecast: React.FC<ModalForecastProps> = ({
@@ -53,6 +55,9 @@ const ModalForecast: React.FC<ModalForecastProps> = ({
   clockType,
   units,
   initialPosition,
+  maxHeight,
+  onScrollOffsetChange,
+  onScrollOffsetMaxChange,
 }) => {
   const { fontScale } = useWindowDimensions();
   const [currentIndex, setCurrentIndex] = useState<number>(0);
@@ -102,11 +107,10 @@ const ModalForecast: React.FC<ModalForecastProps> = ({
     setCurrentIndex(index);
   };
 
-  // Large content should have horizontal scrolling,
-  // otherwise disable scrolling so that swipe to close works
-  const shouldHorizontalScroll = height < 500 || (height < 900 && displayParams.length > MAX_PARAMETERS_WITHOUT_SCROLL);
   const isWideDisplay = width > 500;
-  const maxTableHeight = isWideDisplay ? height - 130 : height - 150;
+  const timeSelectorHeight = isWideDisplay ? 0 : 48;
+  const modalChromeHeight = 70 + 16 + timeSelectorHeight;
+  const maxTableHeight = Math.max(160, (maxHeight ?? height) - modalChromeHeight);
 
   // eslint-disable-next-line react/no-unstable-nested-components
   const DayDurationRow = () => {
@@ -464,15 +468,18 @@ const ModalForecast: React.FC<ModalForecastProps> = ({
           }}
         />
       )}
-      {shouldHorizontalScroll ? (
-        <ScrollView style={[styles.table, { maxHeight: maxTableHeight }]}>
-          {modalContent}
-        </ScrollView>
-      ) : (
-        <View style={[styles.table, { maxHeight: maxTableHeight }]}>
-          {modalContent}
-        </View>
-      )}
+      <ScrollView
+        nestedScrollEnabled
+        onContentSizeChange={(_, contentHeight) => {
+          onScrollOffsetMaxChange?.(Math.max(0, contentHeight - maxTableHeight));
+        }}
+        onScroll={({ nativeEvent }) => {
+          onScrollOffsetChange?.(nativeEvent.contentOffset.y);
+        }}
+        scrollEventThrottle={16}
+        style={[styles.table, { maxHeight: maxTableHeight }]}>
+        {modalContent}
+      </ScrollView>
     </>
   );
 };

--- a/src/components/weather/forecast/Vertical10DaysForecast.tsx
+++ b/src/components/weather/forecast/Vertical10DaysForecast.tsx
@@ -1,8 +1,13 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import {
-  View, StyleSheet, useWindowDimensions, GestureResponderEvent, PanResponderGestureState,
+  View,
+  StyleSheet,
+  useWindowDimensions,
+  GestureResponderEvent,
+  PanResponderGestureState,
   AppState, AppStateStatus
 } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Modal from 'react-native-modal';
 import moment from 'moment';
 import { useTheme } from '@react-navigation/native';
@@ -25,7 +30,6 @@ import Icon from '@components/common/ScalableIcon';
 import { formatAccessibleDate, formatAccessibleTemperature, uppercaseFirst } from '@utils/helpers';
 import ModalContent from './ModalContent';
 import { trackMatomoEvent } from '@utils/matomo';
-import { MAX_PARAMETERS_WITHOUT_SCROLL } from './constants';
 
 const mapStateToProps = (state: State) => ({
   units: selectUnits(state),
@@ -57,8 +61,8 @@ const Vertical10DaysForecast: React.FC<DaySelectorListProps> = ({
   dayData,
   units,
   invalidData,
-  displayParams,
 }) => {
+  const insets = useSafeAreaInsets();
   const { width, height, fontScale} = useWindowDimensions();
   const { colors, dark } = useTheme() as CustomTheme;
   const { t, i18n } = useTranslation();
@@ -66,6 +70,7 @@ const Vertical10DaysForecast: React.FC<DaySelectorListProps> = ({
   const decimalSeparator = locale === 'en' ? '.' : ',';
   const isWideDisplay = () => width > 500;
   const largeFonts = fontScale >= 1.5;
+  const modalMaxHeight = height - insets.top - insets.bottom - 20;
 
   const activeParameters = Config.get('weather').forecast.data.flatMap(
     ({ parameters }) => parameters
@@ -80,9 +85,32 @@ const Vertical10DaysForecast: React.FC<DaySelectorListProps> = ({
   const [modalTimeStamp, setModalTimeStamp] = useState(0);
   const [modalActiveDayIndex, setModalActiveDayIndex] = useState(0);
   const [initialPosition, setInitialPosition] = useState<'start' | 'end'>('start');
+  const [modalScrollOffset, setModalScrollOffset] = useState(0);
+  const [modalScrollOffsetMax, setModalScrollOffsetMax] = useState(0);
 
-  const shouldHorizontalScroll = height < 500 ||
-                                (height < 900 && displayParams.length > MAX_PARAMETERS_WITHOUT_SCROLL);
+  const shouldPropagateModalSwipe = useCallback(
+    (_: GestureResponderEvent, gestureState: PanResponderGestureState) => {
+      const { dx, dy } = gestureState;
+      const edgeTolerance = 2;
+      const isAtTop = modalScrollOffset <= edgeTolerance;
+      const isAtBottom =
+        modalScrollOffsetMax <= edgeTolerance ||
+        modalScrollOffset >= modalScrollOffsetMax - edgeTolerance;
+
+      if (Math.abs(dx) > Math.abs(dy)) {
+        return true;
+      }
+      if (dy > 0 && isAtTop) {
+        return false;
+      }
+      if (dy < 0 && isAtBottom) {
+        return false;
+      }
+
+      return true;
+    },
+    [modalScrollOffset, modalScrollOffsetMax]
+  );
 
   const appState = useRef<AppStateStatus>(AppState.currentState);
 
@@ -296,23 +324,22 @@ const Vertical10DaysForecast: React.FC<DaySelectorListProps> = ({
         onBackButtonPress={ () => setModalVisible(false ) }
         onBackdropPress={ () => setModalVisible(false ) }
         swipeDirection={['down', 'up']}
-        propagateSwipe={(_: GestureResponderEvent, gestureState: PanResponderGestureState) => {
-          if (shouldHorizontalScroll) return true;
-
-          const { dx, dy } = gestureState;
-          if (Math.abs(dx) > Math.abs(dy)) {
-            return true;
-          }
-          return false;
-        }}
+        scrollOffset={modalScrollOffset}
+        scrollOffsetMax={modalScrollOffsetMax}
+        propagateSwipe={shouldPropagateModalSwipe}
       >
         <View style={styles.centeredView}>
-          <View style={[styles.modalView, { backgroundColor: colors.modalBackground }]}>
+          <View style={
+            [styles.modalView, { backgroundColor: colors.modalBackground, maxHeight: modalMaxHeight }]
+          }>
             <ModalContent
               activeDayIndex={modalActiveDayIndex}
               timeStamp={modalTimeStamp}
               onClose={() => setModalVisible(false) }
               initialPosition={initialPosition}
+              modalMaxHeight={modalMaxHeight}
+              onScrollOffsetChange={setModalScrollOffset}
+              onScrollOffsetMaxChange={setModalScrollOffsetMax}
               onDayChange={ (forward: boolean) => {
                 let newDayIndex = forward ? modalActiveDayIndex + 1 : modalActiveDayIndex - 1;
                 if (newDayIndex < 0) newDayIndex = 0;
@@ -372,7 +399,6 @@ const styles = StyleSheet.create({
     width: 58,
   },
   centeredView: {
-    flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
   },
@@ -381,6 +407,7 @@ const styles = StyleSheet.create({
     borderRadius: 20,
     padding: 8,
     alignItems: 'center',
+    overflow: 'hidden',
     shadowColor: BLACK,
     shadowOffset: {
       width: 0,

--- a/src/components/weather/forecast/constants.ts
+++ b/src/components/weather/forecast/constants.ts
@@ -1,1 +1,0 @@
-export const MAX_PARAMETERS_WITHOUT_SCROLL = 9;


### PR DESCRIPTION
- Added safe area handling so that modal doesn't overlap statusbar
- Improved swipe to close functionality so that `MAX_PARAMETERS_WITHOUT_SCROLL` is not needed anymore
