### PR TITLE
issue-1254: Removed producer from forecast meta parameters

### DIFF
--- a/src/network/WeatherApi.ts
+++ b/src/network/WeatherApi.ts
@@ -59,8 +59,6 @@ export const getForecast = async (
       'moonPhase',
       'modtime',
       'dark',
-      // Remove producer if it causes problems with Smartmet Server
-      'producer',
     ],
     ['geoid', 'epochtime'],
   ];


### PR DESCRIPTION
FMI version seems to work fine without it and producer-parameter doesn't work with international installations of Smartmet Server.

Closes #1254 