### PR TITLE
issue-1292: Dependabot configuration and other security improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/Helsinki"
+    cooldown:
+      default-days: 3
+    open-pull-requests-limit: 10
+    versioning-strategy: "increase"
+    labels:
+      - "dependencies"
+      - "javascript"
+    groups:
+      npm-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "react-native"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+      - dependency-name: "react"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+      - dependency-name: "react-test-renderer"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,22 @@
+name: Dependency review
+
+on:
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dependency-review:
+    name: Critical vulnerabilities
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: critical

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -6,4 +6,6 @@
 if [ "$GITHUB_ACTIONS" != "true" ]; then
   yarn lint:ts
   yarn test --watchman=false
+  # Checks secret leaks in the commits that are being pushed
+  gitleaks detect --log-opts="@{u}..HEAD"
 fi

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=72h

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ This project is licensed under the MIT Licence - see the [LICENSE](LICENSE) file
 
 ## **Installation**
 
+Homebrew package manager for macOS is required: https://brew.sh/
+
+`brew install cocoapods`
+`brew install gitleaks`
+
 `git clone --recurse-submodules https://github.com/fmidev/weather-app.git `
 
 `cd weather-app`


### PR DESCRIPTION
- Dependabot is run once a week and creates PRs for package upgrades
- Dependency review is run for PRs
- gitleaks is run in pre-push hook
- .npmrc was added with min-release-age setting

Closes #1292 