### PR TITLE
issue-575: Added close button for maintenance banners

### DIFF
--- a/__tests__/components/AnnouncementStrip.test.tsx
+++ b/__tests__/components/AnnouncementStrip.test.tsx
@@ -4,12 +4,19 @@ import { fireEvent, render } from '@testing-library/react-native';
 import { Provider } from 'react-redux';
 
 import AnnouncementStrip from '../../src/components/announcements/AnnouncementStrip';
-import { DARK_RED, LIGHT_RED, LIGHT_BLUE } from '../../src/assets/colors';
+import {
+  CRISIS_BG,
+  MAINTENANCE_BG,
+} from '../../src/assets/colors';
 
 const mockConfigGet = jest.fn();
 const mockSelectCrisis = jest.fn();
 const mockSelectMaintenance = jest.fn();
 const mockSelectFetchTimestamp = jest.fn<any, any[]>(() => 0);
+const mockDismissAnnouncement = jest.fn((id: string) => ({
+  type: 'DISMISS_ANNOUNCEMENT',
+  id,
+}));
 
 jest.mock('@config', () => ({
   Config: {
@@ -27,6 +34,7 @@ jest.mock('@store/announcements/actions', () => ({
   fetchAnnouncements: () => ({
     type: 'ANNOUNCEMENTS/FETCH',
   }),
+  dismissAnnouncement: (id: string) => mockDismissAnnouncement(id),
 }));
 
 jest.mock('react-i18next', () => ({
@@ -54,6 +62,24 @@ jest.mock('../../src/components/announcements/AnnouncementIcon', () => ({
   default: ({ type }: { type: string }) => {
     const { Text: MockText } = require('react-native');
     return <MockText testID={`announcement-strip-icon-${type}`}>{type}</MockText>;
+  },
+}));
+
+jest.mock('@components/common/CloseButton', () => ({
+  __esModule: true,
+  default: ({ onPress, accessibilityLabel }: any) => {
+    const {
+      Text: MockText,
+      TouchableOpacity,
+    } = require('react-native');
+    return (
+      <TouchableOpacity
+        accessibilityLabel={accessibilityLabel}
+        onPress={onPress}
+        testID="announcement-strip-close-button">
+        <MockText>{accessibilityLabel}</MockText>
+      </TouchableOpacity>
+    );
   },
 }));
 
@@ -91,6 +117,7 @@ describe('AnnouncementStrip', () => {
     mockSelectCrisis.mockReset();
     mockSelectMaintenance.mockReset();
     mockSelectFetchTimestamp.mockClear();
+    mockDismissAnnouncement.mockClear();
     mockIcon.mockClear();
   });
 
@@ -127,12 +154,13 @@ describe('AnnouncementStrip', () => {
   it('renders maintenance announcement without link as plain text', () => {
     mockSelectCrisis.mockReturnValue(undefined);
     mockSelectMaintenance.mockReturnValue({
+      id: 'maintenance-1',
       content: 'Planned maintenance at 10:00',
       link: 'maintenance-info',
     });
 
     const store = createStore({ mock: {} });
-    const { getByText, queryByA11yRole, getByA11yLabel, toJSON } = render(
+    const { getByText, queryByA11yRole, getByA11yLabel, getByTestId, toJSON } = render(
       <Provider store={store as any}>
         <AnnouncementStrip type="maintenance" />
       </Provider>
@@ -142,14 +170,22 @@ describe('AnnouncementStrip', () => {
     expect(getByA11yLabel('Maintenance Planned maintenance at 10:00')).toBeTruthy();
     expect(queryByA11yRole('link')).toBeNull();
 
+    fireEvent.press(getByTestId('announcement-strip-close-button'));
+
+    expect(mockDismissAnnouncement).toHaveBeenCalledWith('maintenance-1');
+    expect(store.dispatch).toHaveBeenCalledWith({
+      type: 'DISMISS_ANNOUNCEMENT',
+      id: 'maintenance-1',
+    });
+
     const tree = toJSON() as any;
     const styleArray = Array.isArray(tree.props.style)
       ? tree.props.style
       : [tree.props.style];
     const mergedStyle = Object.assign({}, ...styleArray);
 
-    expect(mergedStyle.backgroundColor).toBe(LIGHT_BLUE);
-    expect(mergedStyle.paddingTop).toBe(17);
+    expect(mergedStyle.backgroundColor).toBe(MAINTENANCE_BG);
+    expect(mergedStyle.paddingTop).toBe(12);
   });
 
   it('renders crisis announcement as link and opens browser on press', async () => {
@@ -170,15 +206,6 @@ describe('AnnouncementStrip', () => {
     expect(getByA11yHint('Open in browser')).toBeTruthy();
     expect(getByA11yLabel('Crisis Storm warning in effect')).toBeTruthy();
     expect(getByTestId('announcement-strip-icon-crisis')).toBeTruthy();
-    expect(getByTestId('icon-open-in-new')).toBeTruthy();
-    expect(mockIcon).toHaveBeenCalledWith(
-      expect.objectContaining({
-        name: 'open-in-new',
-        color: DARK_RED,
-        width: 18,
-        height: 18,
-      })
-    );
 
     const tree = toJSON() as any;
     const styleArray = Array.isArray(tree.props.style)
@@ -186,15 +213,10 @@ describe('AnnouncementStrip', () => {
       : [tree.props.style];
     const mergedStyle = Object.assign({}, ...styleArray);
 
-    expect(mergedStyle.backgroundColor).toBe(LIGHT_RED);
+    expect(mergedStyle.backgroundColor).toBe(CRISIS_BG);
 
     fireEvent.press(getByA11yRole('link'));
 
     expect(openURLSpy).toHaveBeenCalledWith('https://example.test/crisis');
-    expect(mockIcon).toHaveBeenCalledWith(
-      expect.objectContaining({
-        color: DARK_RED,
-      })
-    );
   });
 });

--- a/__tests__/components/AnnouncementStrip.test.tsx
+++ b/__tests__/components/AnnouncementStrip.test.tsx
@@ -57,6 +57,12 @@ jest.mock('react-native-safe-area-context', () => ({
   }),
 }));
 
+jest.mock('@react-navigation/native', () => ({
+  useRoute: () => ({
+    name: 'StackWeather',
+  }),
+}));
+
 jest.mock('../../src/components/announcements/AnnouncementIcon', () => ({
   __esModule: true,
   default: ({ type }: { type: string }) => {

--- a/__tests__/store/announcements.test.ts
+++ b/__tests__/store/announcements.test.ts
@@ -16,6 +16,8 @@ const maintenance = {
   type: 'Maintenance',
 } as any;
 
+const dismissed = [] as Array<string>;
+
 describe('announcements store', () => {
   it('handles fetch lifecycle actions', () => {
     expect(
@@ -33,6 +35,7 @@ describe('announcements store', () => {
       })
     ).toMatchObject({
       data: [announcement],
+      dismissed,
       error: false,
       fetchSuccessTime: 123,
       fetchTimestamp: 123,
@@ -56,6 +59,7 @@ describe('announcements store', () => {
     const state = {
       announcements: {
         data: [announcement, maintenance],
+        dismissed,
         error: false,
         fetchSuccessTime: 123,
         fetchTimestamp: 123,

--- a/__tests__/utils/helpers.test.ts
+++ b/__tests__/utils/helpers.test.ts
@@ -424,26 +424,26 @@ describe('helpers getSeveritiesForDays', () => {
   });
 
   it('returns severities for all four 6-hour periods in a day', () => {
-    const date = moment.utc('2035-06-01T00:00:00Z').valueOf();
+    const date = moment('2035-06-01T00:00:00').valueOf();
     const warnings = [
       makeWarning(
-        '2035-06-01T01:00:00Z',
-        '2035-06-01T02:00:00Z',
+        '2035-06-01T01:00:00',
+        '2035-06-01T02:00:00',
         'Moderate'
       ), // 00-06
       makeWarning(
-        '2035-06-01T07:00:00Z',
-        '2035-06-01T08:00:00Z',
+        '2035-06-01T07:00:00',
+        '2035-06-01T08:00:00',
         'Severe'
       ), // 06-12
       makeWarning(
-        '2035-06-01T13:00:00Z',
-        '2035-06-01T14:00:00Z',
+        '2035-06-01T13:00:00',
+        '2035-06-01T14:00:00',
         'Extreme'
       ), // 12-18
       makeWarning(
-        '2035-06-01T19:00:00Z',
-        '2035-06-01T20:00:00Z',
+        '2035-06-01T19:00:00',
+        '2035-06-01T20:00:00',
         'Moderate'
       ), // 18-24
     ];

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -702,7 +702,8 @@
   "announcements": {
     "crisisPrefix": "Warning:",
     "maintenancePrefix": "Attention:",
-    "openInBrowser": "Open in browser"
+    "openInBrowser": "Open in browser",
+    "closeAnnouncement": "Close announcement"
   },
   "news": {
     "title": "News",

--- a/i18n/fi.json
+++ b/i18n/fi.json
@@ -702,7 +702,8 @@
   "announcements": {
     "crisisPrefix": "Varoitus:",
     "maintenancePrefix": "Huomio:",
-    "openInBrowser": "Avaa selaimessa"
+    "openInBrowser": "Avaa selaimessa",
+    "closeAnnouncement": "Sulje ilmoitus"
   },
   "news": {
     "title": "Ajankohtaista",

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -701,7 +701,8 @@
   "announcements": {
     "crisisPrefix": "Varning:",
     "maintenancePrefix": "OBS:",
-    "openInBrowser": "Öppna i webbläsaren"
+    "openInBrowser": "Öppna i webbläsaren",
+    "closeAnnouncement": "Stäng meddelande"
   },
   "news": {
     "title": "Aktuellt",

--- a/src/components/announcements/AnnouncementStrip.tsx
+++ b/src/components/announcements/AnnouncementStrip.tsx
@@ -9,6 +9,7 @@ import {
 import { connect, ConnectedProps } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useRoute } from '@react-navigation/native';
 
 import AccessibleTouchableOpacity from '@components/common/AccessibleTouchableOpacity';
 
@@ -60,6 +61,7 @@ const AnnouncementStrip: React.FC<AnnouncementStripProps> = ({
   dismissAnnouncement,
 }) => {
   const insets = useSafeAreaInsets();
+  const route = useRoute();
   const { t } = useTranslation('announcements');
   const { enabled } = Config.get('announcements');
   const { layout } = Config.get('weather');
@@ -68,7 +70,7 @@ const AnnouncementStrip: React.FC<AnnouncementStripProps> = ({
   const backgroundColor = type === 'crisis' ? CRISIS_BG : MAINTENANCE_BG;
   const textColor = type === 'crisis' ? CRISIS_TEXT : MAINTENANCE_TEXT;
   const prefix = type === 'crisis' ? t('crisisPrefix') : t('maintenancePrefix');
-  const paddingTop = layout === 'fmi' ? insets.top : 5;
+  const paddingTop = layout === 'fmi' && route.name === 'StackWeather' ? insets.top : 5;
 
   if (!announcement || !enabled) {
     return null;

--- a/src/components/announcements/AnnouncementStrip.tsx
+++ b/src/components/announcements/AnnouncementStrip.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {
   View,
-  Text,
   StyleSheet,
   Linking,
   StyleProp,
@@ -11,7 +10,6 @@ import { connect, ConnectedProps } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
-import Icon from '@assets/Icon';
 import AccessibleTouchableOpacity from '@components/common/AccessibleTouchableOpacity';
 
 import { Config } from '@config';
@@ -21,10 +19,17 @@ import {
   selectMaintenance,
   selectFetchTimestamp,
 } from '@store/announcements/selectors';
-import { fetchAnnouncements as fetchAnnouncementsAction } from '@store/announcements/actions';
+import {
+  fetchAnnouncements as fetchAnnouncementsAction,
+  dismissAnnouncement as dismissAnnouncementAction,
+} from '@store/announcements/actions';
 
-import { LIGHT_RED, DARK_RED, LIGHT_BLUE, PRIMARY_BLUE } from '@assets/colors';
+import {
+  CRISIS_BG, CRISIS_TEXT, MAINTENANCE_BG, MAINTENANCE_TEXT
+} from '@assets/colors';
+import Text from '@components/common/AppText';
 import AnnouncementIcon from './AnnouncementIcon';
+import CloseButton from '@components/common/CloseButton';
 import type { AnnouncementType } from './types';
 
 const mapStateToProps = (state: State) => ({
@@ -35,6 +40,7 @@ const mapStateToProps = (state: State) => ({
 
 const mapDispatchToProps = {
   fetchAnnouncements: fetchAnnouncementsAction,
+  dismissAnnouncement: dismissAnnouncementAction,
 };
 
 const connector = connect(mapStateToProps, mapDispatchToProps);
@@ -51,6 +57,7 @@ const AnnouncementStrip: React.FC<AnnouncementStripProps> = ({
   type,
   crisis,
   maintenance,
+  dismissAnnouncement,
 }) => {
   const insets = useSafeAreaInsets();
   const { t } = useTranslation('announcements');
@@ -58,10 +65,10 @@ const AnnouncementStrip: React.FC<AnnouncementStripProps> = ({
   const { layout } = Config.get('weather');
 
   const announcement = type === 'crisis' ? crisis : maintenance;
-  const backgroundColor = type === 'crisis' ? LIGHT_RED : LIGHT_BLUE;
-  const textColor = type === 'crisis' ? DARK_RED : PRIMARY_BLUE;
+  const backgroundColor = type === 'crisis' ? CRISIS_BG : MAINTENANCE_BG;
+  const textColor = type === 'crisis' ? CRISIS_TEXT : MAINTENANCE_TEXT;
   const prefix = type === 'crisis' ? t('crisisPrefix') : t('maintenancePrefix');
-  const paddingTop = layout === 'fmi' ? insets.top + 5 : 5;
+  const paddingTop = layout === 'fmi' ? insets.top : 5;
 
   if (!announcement || !enabled) {
     return null;
@@ -71,36 +78,46 @@ const AnnouncementStrip: React.FC<AnnouncementStripProps> = ({
   const isLink = linkRegex.test(announcement.link);
 
   return (
-    <View style={[style, styles.container, { backgroundColor, paddingTop }]}>
-      <View style={styles.iconContainer}>
-        <AnnouncementIcon type={type} />
-      </View>
-      {isLink ? (
-        <AccessibleTouchableOpacity
-          style={styles.touchable}
-          accessibilityRole="link"
-          accessibilityHint={t('openInBrowser')}
-          onPress={() => Linking.openURL(announcement.link)}>
-          <View style={[styles.textContainer]}>
-            <Text
-              style={[styles.text, styles.link, { color: textColor }]}
-              accessibilityLabel={`${prefix} ${announcement.content}`}>
-              {announcement.content}
-            </Text>
-          </View>
-          <View style={[styles.iconContainer, styles.rightIcon]}>
-            <Icon name="open-in-new" color={textColor} width={18} height={18} />
-          </View>
-        </AccessibleTouchableOpacity>
-      ) : (
-        <View style={styles.textContainer}>
-          <Text
-            style={[styles.text, { color: textColor }]}
-            accessibilityLabel={`${prefix} ${announcement.content}`}>
-            {announcement.content}
-          </Text>
+    <View style={{ backgroundColor, paddingTop }}>
+      <View style={[style, styles.container]}>
+        <View style={styles.iconColumn}>
+          <AnnouncementIcon type={type} />
         </View>
-      )}
+        <View style={styles.contentColumn}>
+          {isLink ? (
+            <AccessibleTouchableOpacity
+              style={styles.touchable}
+              accessibilityRole="link"
+              accessibilityHint={t('openInBrowser')}
+              onPress={() => Linking.openURL(announcement.link)}>
+              <View style={styles.linkTextContainer}>
+                <Text
+                  style={[styles.text, styles.link, { color: textColor }]}
+                  accessibilityLabel={`${prefix} ${announcement.content}`}>
+                  {announcement.content}
+                </Text>
+              </View>
+            </AccessibleTouchableOpacity>
+          ) : (
+            <View>
+              <Text
+                style={[styles.text, { color: textColor }]}
+                accessibilityLabel={`${prefix} ${announcement.content}`}>
+                {announcement.content}
+              </Text>
+            </View>
+          )}
+        </View>
+        <View style={styles.closeColumn}>
+          {type === 'maintenance' && (
+            <CloseButton
+              onPress={() => dismissAnnouncement(announcement.id)}
+              accessibilityLabel={t('closeAnnouncement')}
+              size={32}
+            />
+          )}
+        </View>
+      </View>
     </View>
   );
 };
@@ -109,33 +126,36 @@ const styles = StyleSheet.create({
   container: {
     padding: 12,
     flexDirection: 'row',
+    alignItems: 'center',
   },
-  iconContainer: {
+  iconColumn: {
     justifyContent: 'center',
     alignItems: 'center',
+  },
+  contentColumn: {
+    flex: 1,
+    marginHorizontal: 12,
+  },
+  closeColumn: {
+    width: 44,
+    alignItems: 'flex-end',
+    justifyContent: 'center',
   },
   text: {
     fontFamily: 'Roboto-Medium',
     fontSize: 16,
-    alignItems: 'flex-end',
-  },
-  textContainer: {
-    alignItems: 'flex-start',
-    marginLeft: 12,
     flexShrink: 1,
   },
   link: {
     textDecorationLine: 'underline',
   },
-  rightIcon: {
-    flexGrow: 1,
-    justifyContent: 'flex-end',
-    alignItems: 'flex-end',
-    marginRight: 24,
+  linkTextContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
   },
   touchable: {
     minHeight: 18,
-    width: '100%',
     flexDirection: 'row',
     justifyContent: 'flex-start',
   },

--- a/src/components/announcements/AnnouncementStrip.tsx
+++ b/src/components/announcements/AnnouncementStrip.tsx
@@ -113,7 +113,6 @@ const AnnouncementStrip: React.FC<AnnouncementStripProps> = ({
             <CloseButton
               onPress={() => dismissAnnouncement(announcement.id)}
               accessibilityLabel={t('closeAnnouncement')}
-              size={32}
             />
           )}
         </View>

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -28,7 +28,7 @@ const MapScreen: React.FC<MapScreenProps> = ({mapLibrary}) => {
   const mapLayersSheetRef = useRef<RBSheet>(null);
   const infoSheetRef = useRef<RBSheet>(null);
 
-    const largeFonts = fontScale > 1.5;
+  const largeFonts = fontScale > 1.5;
 
   return (
     <>

--- a/src/store/announcements/actions.ts
+++ b/src/store/announcements/actions.ts
@@ -5,6 +5,7 @@ import {
   FETCH_ANNOUNCEMENTS,
   FETCH_ANNOUNCEMENTS_SUCCESS,
   FETCH_ANNOUNCEMENTS_ERROR,
+  DISMISS_ANNOUNCEMENT,
   AnnouncementActionTypes,
 } from './types';
 
@@ -27,6 +28,11 @@ const fetchAnnouncements =
           timestamp: Date.now(),
         });
       });
+  };
+
+export const dismissAnnouncement =
+  (announcementId: string) => (dispatch: Dispatch<AnnouncementActionTypes>) => {
+    dispatch({ type: DISMISS_ANNOUNCEMENT, id: announcementId });
   };
 
 export default fetchAnnouncements;

--- a/src/store/announcements/reducer.ts
+++ b/src/store/announcements/reducer.ts
@@ -5,10 +5,12 @@ import {
   FETCH_ANNOUNCEMENTS,
   FETCH_ANNOUNCEMENTS_SUCCESS,
   FETCH_ANNOUNCEMENTS_ERROR,
+  DISMISS_ANNOUNCEMENT,
 } from './types';
 
 const INITIAL_STATE: AnnouncementsState = {
   data: [],
+  dismissed: [],
   loading: false,
   error: false,
   fetchTimestamp: Date.now(),
@@ -48,6 +50,14 @@ export default (
       };
     }
 
+    case DISMISS_ANNOUNCEMENT: {
+      return {
+        ...state,
+        data: state.data.filter((announcement) => announcement.id !== action.id),
+        dismissed: [...state.dismissed, action.id],
+      };
+    }
+
     default: {
       return state;
     }
@@ -56,5 +66,5 @@ export default (
 
 export const announcementsPersist: PersistConfig = {
   key: 'announcements',
-  whitelist: [],
+  whitelist: ['dismissed'],
 };

--- a/src/store/announcements/selectors.ts
+++ b/src/store/announcements/selectors.ts
@@ -21,6 +21,11 @@ export const selectAnnouncements = createSelector(
   (announcements) => announcements.data
 );
 
+export const selectDismissedAnnouncements = createSelector(
+  selectAnnouncementsDomain,
+  (announcements) => announcements.dismissed
+);
+
 export const selectCrisis = createSelector(
   selectAnnouncements,
   (announcements) =>
@@ -30,11 +35,13 @@ export const selectCrisis = createSelector(
 );
 
 export const selectMaintenance = createSelector(
-  selectAnnouncements,
-  (announcements) =>
+  selectAnnouncements, selectDismissedAnnouncements,
+  (announcements, dismissed) =>
     announcements &&
     announcements.length > 0 &&
-    announcements.filter((a) => a.type === 'Maintenance')[0]
+    announcements.filter(
+      (a) => a.type === 'Maintenance' && !dismissed.includes(a.id)
+    )[0]
 );
 
 export const selectFetchTimestamp = createSelector(

--- a/src/store/announcements/types.ts
+++ b/src/store/announcements/types.ts
@@ -1,6 +1,7 @@
 export const FETCH_ANNOUNCEMENTS = 'FETCH_ANNOUNCEMENTS';
 export const FETCH_ANNOUNCEMENTS_SUCCESS = 'FETCH_ANNOUNCEMENTS_SUCCESS';
 export const FETCH_ANNOUNCEMENTS_ERROR = 'FETCH_ANNOUNCEMENTS_ERROR';
+export const DISMISS_ANNOUNCEMENT = 'DISMISS_ANNOUNCEMENT';
 
 interface FetchAnnouncements {
   type: typeof FETCH_ANNOUNCEMENTS;
@@ -18,12 +19,19 @@ interface FetchAnnouncementsError {
   timestamp: number;
 }
 
+interface DismissAnnouncement {
+  type: typeof DISMISS_ANNOUNCEMENT;
+  id: string;
+}
+
 export type AnnouncementActionTypes =
   | FetchAnnouncements
   | FetchAnnouncementsSuccess
-  | FetchAnnouncementsError;
+  | FetchAnnouncementsError
+  | DismissAnnouncement;
 
 export interface Announcement {
+  id: string;
   type: 'Maintenance' | 'Crisis';
   content: string;
   link: string;
@@ -36,6 +44,7 @@ export interface Error {
 
 export interface AnnouncementsState {
   data: Announcement[];
+  dismissed: string[]; // Array of dismissed announcement IDs
   loading: boolean;
   error: boolean | Error | string;
   fetchTimestamp: number;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -59,7 +59,7 @@ export default combineReducers({
     WarningsReducer
   ),
   announcements: persistReducer(
-    persistReducerConfig(announcementsPersist),
+    mmkvReducerConfig(announcementsPersist),
     AnnouncementsReducer
   ),
   meteorologist: persistReducer(


### PR DESCRIPTION
Dismissed announcement ids are stored in persistent Redux state and same announcement is not displayed anymore.

Closes #575