### PR TITLE
Fix TimeSlider becoming unresponsive after returning to Map tab

### DIFF
--- a/src/components/map/ui/TimeSlider.tsx
+++ b/src/components/map/ui/TimeSlider.tsx
@@ -93,6 +93,7 @@ const TimeSlider: React.FC<TimeSliderProps> = ({
   const { width } = useWindowDimensions();
   const [sliderWidth, setSliderWidth] = useState<number>(width - 24);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const prevCurrentIndexRef = useRef<number>(-1);
 
   const multiplier = Math.round(width / 400);
 
@@ -152,12 +153,15 @@ const TimeSlider: React.FC<TimeSliderProps> = ({
 
   useEffect(() => {
     if (currentIndex >= 0) {
-      if (!isAnimating) {
+      // Only trigger haptics on actual slider movement, not when sliderTimes
+      // changes underneath (e.g. data refresh after navigating away and back).
+      if (!isAnimating && prevCurrentIndexRef.current !== currentIndex) {
         ReactNativeHapticFeedback.trigger(
           Platform.OS === 'ios' ? 'selection' : 'impactMedium'
         );
       }
       updateSliderTime(sliderTimes[currentIndex] || 0);
+      prevCurrentIndexRef.current = currentIndex;
     }
   }, [currentIndex, sliderTimes, updateSliderTime, isAnimating]);
 
@@ -337,7 +341,11 @@ const TimeSlider: React.FC<TimeSliderProps> = ({
             </ScrollView>
           )}
           {sliderTime === 0 && (
-            <ActivityIndicator size="small" style={styles.sliderWrapper} />
+            <ActivityIndicator
+              size="small"
+              style={styles.sliderWrapper}
+              pointerEvents="none"
+            />
           )}
           {sliderTime > 0 && (
             <>


### PR DESCRIPTION
When the user navigates Map -> Warnings -> Map and the periodic overlay refresh fires, the reducer resets sliderTime to 0. While sliderTime is 0 the ActivityIndicator was rendered as a sibling of the ScrollView inside the same column-flex wrapper without pointerEvents="none", so it captured touches and made the slider unresponsive until the next refresh.

Also gate the haptic trigger so it only fires when currentIndex actually changes (user interaction), not when sliderTimes changes underneath due to a data refresh.