### PR TITLE
issue-1326: Forecast max age can be defined in DynamicConfig

### DIFF
--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -292,6 +292,7 @@ export interface ConfigType {
     layout?: 'default' | 'fmi' | 'legacyWithoutBackgroundColor';
     forecast: {
       ageWarning?: number;
+      maxAge?: number;
       updateInterval: number;
       timePeriod: number | string | 'data';
       forecastLengthTitle?: number;

--- a/src/store/forecast/actions.ts
+++ b/src/store/forecast/actions.ts
@@ -26,8 +26,8 @@ export const fetchForecast =
   async (dispatch: Dispatch<ForecastActionTypes>) => {
     dispatch({ type: FETCH_FORECAST });
 
-    const MAX_FORECAST_AGE = 24; // hours
-    const { forecast: { data: dataSettings } } = Config.get('weather');
+    const { forecast: { data: dataSettings, maxAge } } = Config.get('weather');
+    const forecastMaxAge = maxAge || 24;
 
     try {
       const data = await getForecast(location, country);
@@ -42,7 +42,7 @@ export const fetchForecast =
         const modtime = forecast[id][0].modtime;
         const modtimeMoment = modtime ? moment(modtime+'Z') : undefined;
 
-        if (modtimeMoment && moment().diff(modtimeMoment, 'hours') >= MAX_FORECAST_AGE) {
+        if (modtimeMoment && moment().diff(modtimeMoment, 'hours') >= forecastMaxAge) {
           const producer = dataSettings[index].producer;
           trackMatomoEvent('Error', 'Weather', `Old modtime ${modtime} with producer ${producer} for geoid ${id}`);
           trackMatomoEvent('Error', 'Weather', `Old modtime - version ${packageJSON.version}`);

--- a/src/store/forecast/selectors.ts
+++ b/src/store/forecast/selectors.ts
@@ -8,7 +8,7 @@ import { State } from '../types';
 import { DisplayParameters, ForecastState, TimeStepData } from './types';
 import constants, { DAY_LENGTH } from './constants';
 
-const FORECAST_MAX_AGE = 24;
+const FORECAST_MAX_AGE = 24; // Default if not set in DynamicConfig
 
 const selectForecastDomain: Selector<State, ForecastState> = (state) =>
   state.forecast;
@@ -39,6 +39,9 @@ export const selectForecastAge = createSelector(
 export const selectForecast = createSelector(
   [selectData, selectGeoid, selectHour],
   (items, geoid) => {
+    const { maxAge } = Config.get('weather').forecast;
+    const forecastMaxAge = maxAge || FORECAST_MAX_AGE;
+
     const now = new Date();
     if (items) {
       const locationItems = items[!isNaN(geoid) ? geoid : 0];
@@ -47,7 +50,7 @@ export const selectForecast = createSelector(
 
       const modtime = moment(locationItems?.[0]?.modtime+'Z');
       const duration = moment.duration(moment().diff(modtime));
-      if (duration.asHours() > FORECAST_MAX_AGE) {
+      if (duration.asHours() > forecastMaxAge) {
         return [];
       }
 


### PR DESCRIPTION
Forecasts older than max age are declined and not shown for the user.

Closes #1326 