### PR TITLE
issue-1327: Announcement banners always on top

### DIFF
--- a/__tests__/components/MapControls.test.tsx
+++ b/__tests__/components/MapControls.test.tsx
@@ -5,6 +5,21 @@ import MapControls from '../../src/components/map/ui/MapControls';
 
 const mockUseOrientation = jest.fn();
 
+jest.mock('react-redux', () => ({
+  connect: () => (Component: any) => Component,
+}));
+
+jest.mock('@config', () => ({
+  Config: {
+    get: (key: string) => {
+      if (key === 'announcements') {
+        return { enabled: true };
+      }
+      return {};
+    },
+  },
+}));
+
 jest.mock('react-native-safe-area-context', () => ({
   useSafeAreaInsets: () => ({
     top: 0,

--- a/__tests__/navigators/TabNavigator.test.tsx
+++ b/__tests__/navigators/TabNavigator.test.tsx
@@ -202,6 +202,14 @@ jest.mock('@components/common/CommonHeaderTitle', () => ({
   },
 }));
 
+jest.mock('@components/announcements/AnnouncementsHeader', () => ({
+  __esModule: true,
+  default: () => {
+    const { Text } = require('react-native');
+    return <Text testID="announcements-header">announcements</Text>;
+  },
+}));
+
 jest.mock('@components/common/HeaderBackImage', () => ({
   __esModule: true,
   default: () => null,

--- a/src/components/announcements/AnnouncementStrip.tsx
+++ b/src/components/announcements/AnnouncementStrip.tsx
@@ -9,7 +9,6 @@ import {
 import { connect, ConnectedProps } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useRoute } from '@react-navigation/native';
 
 import AccessibleTouchableOpacity from '@components/common/AccessibleTouchableOpacity';
 
@@ -61,20 +60,20 @@ const AnnouncementStrip: React.FC<AnnouncementStripProps> = ({
   dismissAnnouncement,
 }) => {
   const insets = useSafeAreaInsets();
-  const route = useRoute();
   const { t } = useTranslation('announcements');
   const { enabled } = Config.get('announcements');
-  const { layout } = Config.get('weather');
 
   const announcement = type === 'crisis' ? crisis : maintenance;
   const backgroundColor = type === 'crisis' ? CRISIS_BG : MAINTENANCE_BG;
   const textColor = type === 'crisis' ? CRISIS_TEXT : MAINTENANCE_TEXT;
   const prefix = type === 'crisis' ? t('crisisPrefix') : t('maintenancePrefix');
-  const paddingTop = layout === 'fmi' && route.name === 'StackWeather' ? insets.top : 5;
+  const paddingTop = Math.max(Math.round(insets.top), 5);
 
   if (!announcement || !enabled) {
     return null;
   }
+
+  announcement.content = 'Erittäin pitkä teksti joka testaa kuinka hyvin teksti skaalautuu ja meneekö se useammalle riville vai jääkö se yhteen riviin ja meneekö siitä sitten osittain pois näkyvistä vai näkyykö se kokonaan.';
 
   const linkRegex = new RegExp(/^http.*$/);
   const isLink = linkRegex.test(announcement.link);
@@ -125,7 +124,8 @@ const AnnouncementStrip: React.FC<AnnouncementStripProps> = ({
 
 const styles = StyleSheet.create({
   container: {
-    padding: 12,
+    paddingBottom: 8,
+    paddingHorizontal: 16,
     flexDirection: 'row',
     alignItems: 'center',
   },

--- a/src/components/announcements/AnnouncementStrip.tsx
+++ b/src/components/announcements/AnnouncementStrip.tsx
@@ -73,8 +73,6 @@ const AnnouncementStrip: React.FC<AnnouncementStripProps> = ({
     return null;
   }
 
-  announcement.content = 'Erittäin pitkä teksti joka testaa kuinka hyvin teksti skaalautuu ja meneekö se useammalle riville vai jääkö se yhteen riviin ja meneekö siitä sitten osittain pois näkyvistä vai näkyykö se kokonaan.';
-
   const linkRegex = new RegExp(/^http.*$/);
   const isLink = linkRegex.test(announcement.link);
 

--- a/src/components/announcements/Announcements.tsx
+++ b/src/components/announcements/Announcements.tsx
@@ -30,14 +30,10 @@ const connector = connect(mapStateToProps, mapDispatchToProps);
 type PropsFromRedux = ConnectedProps<typeof connector>;
 
 type AnnouncementsProps = {
-  includeTopInset?: boolean;
   style?: StyleProp<ViewStyle>;
 } & PropsFromRedux;
 
 const Announcements: React.FC<AnnouncementsProps> = ({
-  crisis,
-  includeTopInset,
-  maintenance,
   style,
   fetchAnnouncements,
   fetchTimestamp,
@@ -71,11 +67,8 @@ const Announcements: React.FC<AnnouncementsProps> = ({
 
   return (
     <View style={style}>
-      <AnnouncementStrip includeTopInset={includeTopInset} type="crisis" />
-      <AnnouncementStrip
-        includeTopInset={includeTopInset && !crisis && !!maintenance}
-        type="maintenance"
-      />
+      <AnnouncementStrip type="crisis" />
+      <AnnouncementStrip type="maintenance" />
     </View>
   );
 };

--- a/src/components/announcements/Announcements.tsx
+++ b/src/components/announcements/Announcements.tsx
@@ -11,11 +11,13 @@ import { State } from '@store/types';
 import {
   selectCrisis,
   selectFetchTimestamp,
+  selectMaintenance,
 } from '@store/announcements/selectors';
 import { fetchAnnouncements as fetchAnnouncementsAction } from '@store/announcements/actions';
 
 const mapStateToProps = (state: State) => ({
   crisis: selectCrisis(state),
+  maintenance: selectMaintenance(state),
   fetchTimestamp: selectFetchTimestamp(state),
 });
 
@@ -28,10 +30,14 @@ const connector = connect(mapStateToProps, mapDispatchToProps);
 type PropsFromRedux = ConnectedProps<typeof connector>;
 
 type AnnouncementsProps = {
+  includeTopInset?: boolean;
   style?: StyleProp<ViewStyle>;
 } & PropsFromRedux;
 
 const Announcements: React.FC<AnnouncementsProps> = ({
+  crisis,
+  includeTopInset,
+  maintenance,
   style,
   fetchAnnouncements,
   fetchTimestamp,
@@ -65,8 +71,11 @@ const Announcements: React.FC<AnnouncementsProps> = ({
 
   return (
     <View style={style}>
-      <AnnouncementStrip type="crisis" />
-      <AnnouncementStrip type="maintenance" />
+      <AnnouncementStrip includeTopInset={includeTopInset} type="crisis" />
+      <AnnouncementStrip
+        includeTopInset={includeTopInset && !crisis && !!maintenance}
+        type="maintenance"
+      />
     </View>
   );
 };

--- a/src/components/announcements/AnnouncementsHeader.tsx
+++ b/src/components/announcements/AnnouncementsHeader.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import { Header as StackHeader, type StackHeaderProps } from '@react-navigation/stack';
+import { connect, ConnectedProps } from 'react-redux';
+
+import { Config } from '@config';
+import { State } from '@store/types';
+import {
+  selectCrisis,
+  selectMaintenance,
+} from '@store/announcements/selectors';
+
+import Announcements from './Announcements';
+
+const mapStateToProps = (state: State) => ({
+  crisis: selectCrisis(state),
+  maintenance: selectMaintenance(state),
+});
+
+const connector = connect(mapStateToProps);
+
+type PropsFromRedux = ConnectedProps<typeof connector>;
+
+type AnnouncementsHeaderProps = StackHeaderProps & PropsFromRedux;
+
+const AnnouncementsHeader: React.FC<AnnouncementsHeaderProps> = ({
+  crisis,
+  maintenance,
+  options,
+  ...headerProps
+}) => {
+  const hasAnnouncements =
+    Config.get('announcements').enabled && (crisis || maintenance);
+
+  return (
+    <>
+      {hasAnnouncements && (
+        <Announcements includeTopInset style={styles.announcements} />
+      )}
+      <StackHeader
+        {...headerProps}
+        options={{
+          ...options,
+          headerStatusBarHeight: hasAnnouncements
+            ? 0
+            : options.headerStatusBarHeight,
+        }}
+      />
+    </>
+  );
+};
+
+const styles = StyleSheet.create({
+  announcements: {
+    width: '100%',
+  },
+});
+
+export default connector(AnnouncementsHeader);

--- a/src/components/announcements/AnnouncementsHeader.tsx
+++ b/src/components/announcements/AnnouncementsHeader.tsx
@@ -35,7 +35,7 @@ const AnnouncementsHeader: React.FC<AnnouncementsHeaderProps> = ({
   return (
     <>
       {hasAnnouncements && (
-        <Announcements includeTopInset style={styles.announcements} />
+        <Announcements style={styles.announcements} />
       )}
       <StackHeader
         {...headerProps}

--- a/src/components/map/ui/MapControls.tsx
+++ b/src/components/map/ui/MapControls.tsx
@@ -2,11 +2,29 @@ import React from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTranslation } from 'react-i18next';
+import { connect, ConnectedProps } from 'react-redux';
 import { useOrientation } from '@utils/hooks';
 
 import MapButton from './MapButton';
 import RelocateButton from './RelocateButton';
 import TimeSlider from './TimeSlider';
+import { Config } from '@config';
+import { State } from '@store/types';
+import {
+  selectCrisis,
+  selectMaintenance,
+} from '@store/announcements/selectors';
+
+const ANNOUNCEMENT_STRIP_MAP_OFFSET = 48;
+
+const mapStateToProps = (state: State) => ({
+  crisis: selectCrisis(state),
+  maintenance: selectMaintenance(state),
+});
+
+const connector = connect(mapStateToProps);
+
+type PropsFromRedux = ConnectedProps<typeof connector>;
 
 type MapControlsProps = {
   onLayersPressed: () => void;
@@ -15,9 +33,11 @@ type MapControlsProps = {
   onZoomOut: () => void;
   relocate: () => void;
   showRelocateButton: boolean;
-};
+} & PropsFromRedux;
 
 const MapControls: React.FC<MapControlsProps> = ({
+  crisis,
+  maintenance,
   onLayersPressed,
   onInfoPressed,
   onZoomIn,
@@ -28,12 +48,27 @@ const MapControls: React.FC<MapControlsProps> = ({
   const insets = useSafeAreaInsets();
   const { t } = useTranslation();
   const isLandscape = useOrientation();
+  const announcementsEnabled = Config.get('announcements').enabled;
+  const announcementsOffset =
+    announcementsEnabled
+      ? Number(!!crisis) * ANNOUNCEMENT_STRIP_MAP_OFFSET +
+        Number(!!maintenance) * ANNOUNCEMENT_STRIP_MAP_OFFSET
+      : 0;
+  const announcementsOffsetStyle = announcementsOffset > 0 && {
+    transform: [{ translateY: -announcementsOffset }],
+  };
+
   return (
     <View style={styles.wrapper} pointerEvents="box-none">
       {showRelocateButton && (
         <RelocateButton
           onPress={relocate}
-          style={[styles.mapButton, styles.center, styles.topFirst]}
+          style={[
+            styles.mapButton,
+            styles.center,
+            styles.topFirst,
+            announcementsOffsetStyle,
+          ]}
         />
       )}
       <MapButton
@@ -42,7 +77,8 @@ const MapControls: React.FC<MapControlsProps> = ({
           styles.right,
           styles.topFirst,
           isLandscape && styles.left,
-          isLandscape ? { left: insets.left + 12 } : { right: insets.right + 12 }
+          isLandscape ? { left: insets.left + 12 } : { right: insets.right + 12 },
+          announcementsOffsetStyle,
         ]}
         accessibilityLabel={t('map:plusButtonAccessibilityLabel')}
         onPress={onZoomIn}
@@ -55,7 +91,8 @@ const MapControls: React.FC<MapControlsProps> = ({
           styles.right,
           styles.topSecond,
           isLandscape && styles.left,
-          isLandscape ? { left: insets.left + 12 } : { right: insets.right + 12 }
+          isLandscape ? { left: insets.left + 12 } : { right: insets.right + 12 },
+          announcementsOffsetStyle,
         ]}
         accessibilityLabel={t('map:minusButtonAccessibilityLabel')}
         onPress={onZoomOut}
@@ -68,7 +105,8 @@ const MapControls: React.FC<MapControlsProps> = ({
           styles.mapButton,
           styles.right,
           isLandscape ? styles.topFirst : styles.bottomSecond,
-          { right: insets.right + 12 }
+          { right: insets.right + 12 },
+          announcementsOffsetStyle,
         ]}
         accessibilityLabel={t('map:infoButtonAccessibilityLabel')}
         onPress={onInfoPressed}
@@ -81,7 +119,8 @@ const MapControls: React.FC<MapControlsProps> = ({
           styles.mapButton,
           styles.right,
           isLandscape ? styles.topSecond : styles.bottomFirst,
-          { right: insets.right + 12 }
+          { right: insets.right + 12 },
+          announcementsOffsetStyle,
         ]}
         accessibilityLabel={t('map:layersButtonAccessibilityLabel')}
         onPress={onLayersPressed}
@@ -137,4 +176,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default MapControls;
+export default connector(MapControls);

--- a/src/components/map/ui/TimeSlider.tsx
+++ b/src/components/map/ui/TimeSlider.tsx
@@ -420,7 +420,7 @@ const TimeSlider: React.FC<TimeSliderProps> = ({
 const styles = StyleSheet.create({
   wrapper: {
     position: 'absolute',
-    bottom: 8,
+    bottom: 38,
     right: 12,
     left: 12,
     minHeight: 75,

--- a/src/navigators/TabNavigator.tsx
+++ b/src/navigators/TabNavigator.tsx
@@ -12,7 +12,11 @@ import {
 import { connect, ConnectedProps } from 'react-redux';
 import { NavigationContainer, useNavigationContainerRef } from '@react-navigation/native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
-import { StackNavigationOptions, StackNavigationProp } from '@react-navigation/stack';
+import {
+  StackHeaderProps,
+  StackNavigationOptions,
+  StackNavigationProp,
+} from '@react-navigation/stack';
 import type { NavigationState, Route } from '@react-navigation/routers';
 import RBSheet from 'react-native-raw-bottom-sheet';
 
@@ -32,6 +36,7 @@ import Icon from '@components/common/ScalableIcon';
 import AccessibleTouchableOpacity from '@components/common/AccessibleTouchableOpacity';
 import HeaderButton from '@components/common/HeaderButton';
 import CommonHeaderTitle from '@components/common/CommonHeaderTitle';
+import AnnouncementsHeader from '@components/announcements/AnnouncementsHeader';
 
 import { State } from '@store/types';
 import { selectTheme } from '@store/settings/selectors';
@@ -301,7 +306,11 @@ const Navigator: React.FC<Props> = ({
   );
 
   const mapScreenOptions = useMemo(
-    () => LocationHeaderOptions({ navigation: navigationRef as any })
+    () => ({
+      ...LocationHeaderOptions({ navigation: navigationRef as any }),
+      // eslint-disable-next-line react/no-unstable-nested-components
+      header: (props: StackHeaderProps) => <AnnouncementsHeader {...props} />,
+    })
     , [LocationHeaderOptions, navigationRef]);
 
   const weatherScreenOptions = useMemo(() =>
@@ -311,7 +320,11 @@ const Navigator: React.FC<Props> = ({
     [LocationHeaderOptions, navigationRef, weatherLayout]);
 
   const warningsScreenOptions = useMemo(
-    () => LocationHeaderOptions({ navigation: navigationRef as any }),
+    () => ({
+      ...LocationHeaderOptions({ navigation: navigationRef as any }),
+      // eslint-disable-next-line react/no-unstable-nested-components
+      header: (props: StackHeaderProps) => <AnnouncementsHeader {...props} />,
+    }),
     [LocationHeaderOptions, navigationRef] );
 
   if (!ready || !theme) {

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -6,7 +6,6 @@ import { connect, ConnectedProps } from 'react-redux';
 
 import MlMapView from '@components/map/maps/MlMapView';
 import RnMapview from '@components/map/maps/RnMapView';
-import Announcements from '@components/announcements/Announcements';
 import InfoBottomSheet from '@components/map/sheets/InfoBottomSheet';
 import MapLayersBottomSheet from '@components/map/sheets/MapLayersBottomSheet';
 import { GRAY_1 } from '@assets/colors';
@@ -37,8 +36,6 @@ const MapScreen: React.FC<MapScreenProps> = ({mapLibrary}) => {
         :
         <RnMapview infoSheetRef={infoSheetRef} mapLayersSheetRef={mapLayersSheetRef} />
       }
-
-      <Announcements style={styles.announcements} />
 
       <RBSheet
         ref={infoSheetRef}
@@ -82,10 +79,6 @@ const styles = StyleSheet.create({
   draggableIcon: {
     backgroundColor: GRAY_1,
     width: 65,
-  },
-  announcements: {
-    width: '100%',
-    marginTop: 30,
   },
 });
 

--- a/src/screens/WarningsScreen.tsx
+++ b/src/screens/WarningsScreen.tsx
@@ -11,16 +11,13 @@ import { Config } from '@config';
 import { useReloader } from '@utils/reloader';
 import WarningsWebViewPanel from '@components/warnings/WarningsWebViewPanel';
 import WarningsPanel from '@components/warnings/WarningsPanel';
-import Announcements from '@components/announcements/Announcements';
 import { State } from '@store/types';
 import { connect, ConnectedProps } from 'react-redux';
 import { selectCurrent } from '@store/location/selector';
-import { selectAnnouncements } from '@store/announcements/selectors';
 import CapWarningsView from '@components/warnings/cap/CapWarningsView';
 
 const mapStateToProps = (state: State) => ({
   location: selectCurrent(state),
-  announcements: selectAnnouncements(state),
 });
 
 const mapDispatchToProps = {
@@ -37,7 +34,6 @@ const WarningsScreen: React.FC<WarningsScreenProps> = ({
   fetchWarnings,
   fetchCapWarnings,
   location,
-  announcements,
 }) => {
   const { colors } = useTheme() as CustomTheme;
   const isFocused = useIsFocused();
@@ -87,9 +83,7 @@ const WarningsScreen: React.FC<WarningsScreenProps> = ({
       <ScrollView
         testID="warnings_scrollview"
         style={[styles.container, { backgroundColor: colors.screenBackground }]}
-        showsVerticalScrollIndicator={false}
-        stickyHeaderIndices={announcements && [0]}>
-        <Announcements style={styles.announcements} />
+        showsVerticalScrollIndicator={false}>
         {useCapView ? (
           <CapWarningsView />
         ) : (
@@ -111,9 +105,6 @@ const styles = StyleSheet.create({
   },
   container: {
     minHeight: '100%',
-  },
-  announcements: {
-    elevation: 10,
   },
 });
 


### PR DESCRIPTION
Moved announcement banners to the top of navigation header in Map and Warnings screens.

Closes #1327 