### PR TITLE
issue-1336: Added support for maxDistance and useInKeyword settings

### DIFF
--- a/__tests__/network/WeatherApi.test.ts
+++ b/__tests__/network/WeatherApi.test.ts
@@ -222,6 +222,15 @@ describe('WeatherApi', () => {
   });
 
   it('fetches current position and location locales', async () => {
+    mockConfigGet.mockImplementation((key: string) =>
+      key === 'location'
+        ? {
+            keyword: 'extended_names',
+            maxDistance: 20,
+            useInKeyword: true,
+          }
+        : weatherConfig
+    );
     mockAxiosClient
       .mockResolvedValueOnce({ data: { 123: [{ name: 'Helsinki' }] } })
       .mockResolvedValueOnce({ data: { 123: [{ name: 'Helsinki' }] } });
@@ -235,6 +244,8 @@ describe('WeatherApi', () => {
         params: expect.objectContaining({
           latlon: '60.1,24.9',
           lang: 'en',
+          inkeyword: 'extended_names',
+          maxdistance: 20,
           param: expect.stringContaining('geoid'),
         }),
       },

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -283,6 +283,8 @@ export interface ConfigType {
     keyword: string;
     maxRecent: number;
     maxFavorite: number;
+    maxDistance?: number;
+    useInKeyword?: boolean;
   };
   map: {
     updateInterval: number;

--- a/src/network/WeatherApi.ts
+++ b/src/network/WeatherApi.ts
@@ -268,12 +268,15 @@ export const getCurrentPosition = async (
   longitude: number
 ): Promise<{ [geoid: string]: TimeseriesLocation[] }> => {
   const { apiUrl } = Config.get('weather');
+  const { useInKeyword, keyword, maxDistance } = Config.get('location');
   const { language } = i18n;
 
   const params = {
     ...locationQueryParams,
     latlon: `${latitude},${longitude}`,
     lang: language,
+    ...(useInKeyword ? { inkeyword: keyword } : {}),
+    ...(maxDistance !== undefined ? { maxdistance: maxDistance } : {}),
   };
 
   const { data } = await axiosClient({


### PR DESCRIPTION
Added support for `maxDistance` and `useInKeyword` settings when resolving name for coordinates.

Closes #1336 