### PR TITLE
issue-1371: Added datetime settings to DefaultConfig

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,6 +9,7 @@ import ReduxThunk from 'redux-thunk';
 import NetInfo from '@react-native-community/netinfo';
 
 import '@i18n';
+import '@utils/moment';
 import { ConfigProvider } from '@config';
 import reducers from './src/store';
 import TabNavigator from './src/navigators/TabNavigator';

--- a/__tests__/components/ForecastPanelWithVerticalLayout.test.tsx
+++ b/__tests__/components/ForecastPanelWithVerticalLayout.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import moment from 'moment-timezone';
 import { fireEvent, render } from '@testing-library/react-native';
 
 import ForecastPanelWithVerticalLayout from '../../src/components/weather/ForecastPanelWithVerticalLayout';
+import moment from '../../src/utils/moment';
 
 const mockConfigGet = jest.fn();
 const mockFormatAccessibleDateTime = jest.fn();

--- a/__tests__/components/MeteorologistSnapshot.test.tsx
+++ b/__tests__/components/MeteorologistSnapshot.test.tsx
@@ -31,6 +31,7 @@ jest.mock('@react-navigation/native', () => ({
 
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({
+    i18n: { language: 'en' },
     t: (key: string) => key,
   }),
 }));

--- a/__tests__/components/TimeSlider.test.tsx
+++ b/__tests__/components/TimeSlider.test.tsx
@@ -173,7 +173,7 @@ describe('TimeSlider', () => {
     const expectedTime = moment
       .unix(1710000000)
       .locale('en')
-      .format('ddd HH.mm');
+      .format('ddd HH:mm');
 
     expect(getByTestId('slider-step-1710000000')).toBeTruthy();
     expect(getByTestId('slider-step-1710003600')).toBeTruthy();

--- a/__tests__/config/testConfig.ts
+++ b/__tests__/config/testConfig.ts
@@ -112,6 +112,29 @@ const defaultConfig: ConfigType = {
       light: true,
       dark: true,
     },
+    dateTime: {
+      default: {
+        date: 'D.M.',
+        dateYear: 'D.M.YYYY',
+        longDate: 'Udddd, D.M.',
+        time: 'HH:mm',
+        dateTime: 'D.M. HH:mm',
+        longDateTime: 'D.M.YYYY HH:mm',
+        weekdayAbbreviation: 'Udd',
+        weekday: 'Udddd',
+        weekdayAndDate: 'dddd D.M.',
+        weekdayAbbreviationAndDate: 'Udd D.M.',
+      },
+      locales: {
+        en: {
+          date: 'D MMM',
+          dateTime: 'D MMM HH:mm',
+          weekdayAbbreviation: 'Uddd',
+          weekdayAndDate: 'Udddd D MMM',
+          weekdayAbbreviationAndDate: 'Uddd D MMM',
+        },
+      }
+    },
   },
   announcements: {
     enabled: false,

--- a/__tests__/utils/moment.test.ts
+++ b/__tests__/utils/moment.test.ts
@@ -1,0 +1,41 @@
+import moment from '../../src/utils/moment';
+
+describe('moment formatDateTime extension', () => {
+  const baseMoment = moment.utc('2026-06-15T17:08:00Z');
+
+  it('formats dateTime using locale-specific format when available', () => {
+    expect(baseMoment.formatDateTime('dateTime', 'en')).toBe('15 Jun 17:08');
+  });
+
+  it('formats dateTime with locale fallback to default settings', () => {
+    expect(baseMoment.formatDateTime('dateTime', 'fi')).toBe('15.6. 17:08');
+  });
+
+  it('formats time with default format when locale-specific time is missing', () => {
+    expect(baseMoment.formatDateTime('time', 'en')).toBe('17:08');
+  });
+
+  it('formats dateTime with 12-hour clock time when clock type is 12', () => {
+    expect(baseMoment.formatDateTime('dateTime', 'en', 12)).toBe(
+      '15 Jun 5:08 pm'
+    );
+  });
+
+  it('formats time as 12-hour clock time when clock type is 12', () => {
+    expect(baseMoment.formatDateTime('time', 'en', 12)).toBe('5:08 pm');
+  });
+
+  it('uppercases the first formatted character when format starts with U', () => {
+    expect(baseMoment.formatDateTime('weekday', 'fi')).toBe('Maanantai');
+  });
+
+  it('resolves language tags to base locale for format lookup', () => {
+    expect(baseMoment.formatDateTime('dateTime', 'en-US')).toBe('15 Jun 17:08');
+  });
+
+  it('uses moment instance locale when locale argument is not provided', () => {
+    expect(baseMoment.clone().locale('en').formatDateTime('dateTime')).toBe(
+      '15 Jun 17:08'
+    );
+  });
+});

--- a/defaultConfig.ts.example
+++ b/defaultConfig.ts.example
@@ -117,6 +117,29 @@ const defaultConfig: ConfigType = {
       dark: true,
     },
     clockType: 24,
+    dateTime: {
+      default: {
+        date: 'D.M.',
+        dateYear: 'D.M.YYYY',
+        longDate: 'Udddd, D.M.',
+        time: 'HH:mm',
+        dateTime: 'D.M. HH:mm',
+        longDateTime: 'D.M.YYYY HH:mm',
+        weekdayAbbreviation: 'Udd',
+        weekday: 'Udddd',
+        weekdayAndDate: 'dddd D.M.',
+        weekdayAbbreviationAndDate: 'Udd D.M.',
+      },
+      locales: {
+        en: {
+          date: 'D MMM',
+          dateTime: 'D MMM HH:mm',
+          weekdayAbbreviation: 'Uddd',
+          weekdayAndDate: 'Udddd D MMM',
+          weekdayAbbreviationAndDate: 'Uddd D MMM',
+        },
+      }
+    },
   },
   announcements: {
     enabled: true,

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,5 +1,7 @@
 /* global jest */
 
+import '@utils/moment';
+
 jest.mock('@react-native-async-storage/async-storage', () =>
   require('@react-native-async-storage/async-storage/jest/async-storage-mock')
 );

--- a/src/components/map/ui/TimeSlider.tsx
+++ b/src/components/map/ui/TimeSlider.tsx
@@ -108,17 +108,9 @@ const TimeSlider: React.FC<TimeSliderProps> = ({
       Number(moment(overlay.observation.end).format('X'))) ||
     0;
 
-  const weekdayAbbreviationFormat = locale === 'en' ? 'ddd' : 'dd';
-
-  const currentSliderTime = moment
-    .unix(sliderTime)
-    .locale(locale)
-    .format(
-      `${weekdayAbbreviationFormat} ${clockType === 12 ? 'h.mm a' : 'HH.mm'}`
-    );
-
-  const currentSliderTimeCapitalized =
-    currentSliderTime.charAt(0).toUpperCase() + currentSliderTime.slice(1);
+  const sliderMoment = moment.unix(sliderTime);
+  const currentSliderTime = sliderMoment.formatDateTime('weekdayAbbreviation', locale)
+      + ' ' + sliderMoment.formatDateTime('time', locale, clockType);
 
   const { sliderStep, sliderTimes } = useMemo(() => {
     const minUnix = getSliderMinUnix(activeOverlayId, overlay);
@@ -378,7 +370,7 @@ const TimeSlider: React.FC<TimeSliderProps> = ({
                     color: colors.hourListText,
                   },
                 ]}>
-                {currentSliderTimeCapitalized}
+                {currentSliderTime}
               </Text>
               <Text
                 maxFontSizeMultiplier={1.5}

--- a/src/components/news/NewsView.tsx
+++ b/src/components/news/NewsView.tsx
@@ -26,8 +26,6 @@ const NewsView: React.FC<NewsProps> = ({ item, titleNumberOfLines, gridLayout })
   const { colors } = useTheme() as CustomTheme;
   const { t, i18n } = useTranslation('news');
   const { width } = useWindowDimensions();
-  const dateFormat = 'D.M.YYYY';
-  const dateAndTimeFormat = 'D.M.YYYY HH:mm';
   const titleHeight = titleNumberOfLines ? titleNumberOfLines * 20 : null;
 
   const openLink = async (type: string, id: string) => {
@@ -47,11 +45,11 @@ const NewsView: React.FC<NewsProps> = ({ item, titleNumberOfLines, gridLayout })
 
   const createdMoment = moment(item.createdAt);
   const title =
-    `${t(item.type)} ${createdMoment.format(dateFormat)}` +
+    `${t(item.type)} ${createdMoment.formatDateTime('dateYear', i18n.language)}` +
     (
       item.createdAt.substring(0, 10) !== item.updatedAt.substring(0, 10) &&
       item.showEditedDateTime
-        ? ` (${t('updated')} ${moment(item.updatedAt).format(dateAndTimeFormat)})`
+        ? ` (${t('updated')} ${moment(item.updatedAt).formatDateTime('longDateTime', i18n.language)})`
         : ''
     );
   const accessibleTitle =

--- a/src/components/warnings/DayDetails.tsx
+++ b/src/components/warnings/DayDetails.tsx
@@ -92,15 +92,9 @@ const DayDetails: React.FC<DayDetailsProps> = ({ clockType, warnings }) => {
                     `DD MMMM ${timeFormat}`
                   )}`}>
                   <Text style={styles.bold}>{`${t(`types.${type}`)}`}</Text>
-                  {` – ${t('valid')} ${moment(duration.startTime).format(
-                    locale === 'en'
-                      ? `MMM D ${timeFormat}`
-                      : `D.M. ${timeFormat}`
-                  )} - ${moment(duration.endTime).format(
-                    locale === 'en'
-                      ? `MMM D ${timeFormat}`
-                      : `D.M. ${timeFormat}`
-                  )} `}
+                  {` – ${t('valid')} ${
+                    moment(duration.startTime).formatDateTime('dateTime', locale)
+                    } - ${moment(duration.endTime).formatDateTime('dateTime', locale)} `}
                 </Text>
               </View>
               <View style={styles.iconPadding}>

--- a/src/components/warnings/WarningsPanel.tsx
+++ b/src/components/warnings/WarningsPanel.tsx
@@ -98,7 +98,7 @@ const WarningsPanel: React.FC<WarningsPanelProps> = ({
   }
 
   const locale = i18n.language;
-  const weekdayAbbreviationFormat = locale === 'en' ? 'ddd' : 'dd';
+
   return (
     <View
       testID="warnings_panel"
@@ -227,7 +227,7 @@ const WarningsPanel: React.FC<WarningsPanelProps> = ({
                           color: colors.text,
                         },
                       ]}>
-                      {moment(date).format(weekdayAbbreviationFormat)}
+                      {moment(date).formatDateTime('weekdayAbbreviation', locale)}
                     </Text>
                     <Text
                       maxFontSizeMultiplier={1.5}
@@ -239,7 +239,7 @@ const WarningsPanel: React.FC<WarningsPanelProps> = ({
                           color: colors.text,
                         },
                       ]}>
-                      {moment(date).format(locale === 'en' ? 'MMM D' : 'D.M.')}
+                      {moment(date).formatDateTime('date', locale)}
                     </Text>
                     <SeverityBar severity={severity} />
                   </View>

--- a/src/components/warnings/cap/CapWarningsView.tsx
+++ b/src/components/warnings/cap/CapWarningsView.tsx
@@ -44,8 +44,6 @@ const CapWarningsView: React.FC<CapWarningsViewProps> = ({
 
   const { t, i18n } = useTranslation('warnings');
   const locale = i18n.language;
-  const weekdayAbbreviationFormat = locale === 'en' ? 'ddd' : 'dd';
-  const dateFormat = locale === 'en' ? 'D MMM' : 'D.M.';
 
   const { colors } = useTheme() as CustomTheme;
 
@@ -64,8 +62,8 @@ const CapWarningsView: React.FC<CapWarningsViewProps> = ({
     const dates = [
       {
         time: today.toDate().getTime(),
-        date: moment(today).locale(locale).format(dateFormat),
-        weekday: moment(today).locale(locale).format(weekdayAbbreviationFormat),
+        date: today.formatDateTime('date', locale),
+        weekday: today.formatDateTime('weekdayAbbreviation', locale),
         relativeDay: t('today'),
       },
     ];
@@ -79,10 +77,8 @@ const CapWarningsView: React.FC<CapWarningsViewProps> = ({
 
         dates.push({
           time: momentObject.toDate().getTime(),
-          date: momentObject.locale(locale).format(dateFormat),
-          weekday: momentObject
-            .locale(locale)
-            .format(weekdayAbbreviationFormat),
+          date: momentObject.formatDateTime('date', locale),
+          weekday: momentObject.formatDateTime('weekdayAbbreviation', locale),
           relativeDay,
         });
       }
@@ -139,8 +135,7 @@ const CapWarningsView: React.FC<CapWarningsViewProps> = ({
                     ]}>
                     {moment(updated)
                       .tz(defaultLocation.timezone)
-                      .locale(locale)
-                      .format(locale === 'en' ? 'DD MMM HH.mm' : 'D.M. HH.mm')}
+                      .formatDateTime('dateTime', locale)}
                   </Text>
                 </>
               )}

--- a/src/components/warnings/cap/DaySelectorList.tsx
+++ b/src/components/warnings/cap/DaySelectorList.tsx
@@ -51,7 +51,6 @@ const DaySelector = ({
         <Text
           style={[
             styles.text,
-            styles.capitalized,
             { color: colors.primaryText },
           ]}>
           {capViewSettings?.useRelativeDays ? relativeDay : weekday}
@@ -99,9 +98,6 @@ const DaySelectorList = ({
 );
 
 const styles = StyleSheet.create({
-  capitalized: {
-    textTransform: 'capitalize',
-  },
   container: {
     position: 'absolute',
     top: 12,

--- a/src/components/warnings/cap/LocalWarningsBar.tsx
+++ b/src/components/warnings/cap/LocalWarningsBar.tsx
@@ -122,8 +122,6 @@ const LocalWarningsBar: React.FC<LocalWarningsBarProps> = ({
   const colorMode = dark ? 'dark' : 'light';
 
   const locale = i18n.language;
-  const weekdayAbbreviationFormat = locale === 'en' ? 'ddd' : 'dd';
-  const dateFormat = locale === 'en' ? 'MMM D' : 'D.M.';
   moment.locale(locale);
 
   const preparedWarnings = useMemo(
@@ -316,7 +314,7 @@ const LocalWarningsBar: React.FC<LocalWarningsBarProps> = ({
                         styles.dayWarningHeaderText,
                         { color: colors.primaryText },
                       ]}>
-                      {moment(date).format(weekdayAbbreviationFormat)}
+                      {moment(date).formatDateTime('weekdayAbbreviation', locale)}
                     </Text>
                     <Text
                       maxFontSizeMultiplier={1.5}
@@ -326,7 +324,7 @@ const LocalWarningsBar: React.FC<LocalWarningsBarProps> = ({
                         styles.dayWarningHeaderText,
                         { color: colors.primaryText },
                       ]}>
-                      {moment(date).format(dateFormat)}
+                      {moment(date).formatDateTime('date', locale)}
                     </Text>
                     <View style={styles.severityBarWrapper}>
                       <CapSeverityBar severities={severities} />

--- a/src/components/warnings/cap/LocalWarningsDetails.tsx
+++ b/src/components/warnings/cap/LocalWarningsDetails.tsx
@@ -28,25 +28,22 @@ const LocalWarningsDetails: React.FC<LocalWarningsDetailsProps> = ({
   const { t } = useTranslation('warnings');
   const { colors } = useTheme() as CustomTheme;
 
-  const timeFormat = clockType === 12 ? 'h.mm a' : 'H:mm';
-  const dateFormat = locale === 'en' ? 'D MMM' : 'D.M.';
-  const weekdayAbbreviationFormat = locale === 'en' ? 'ddd' : 'dd';
-
   const warningTimeSpans = warnings.map((warning) => {
     const info = Array.isArray(warning.info) ? warning.info[0] : warning.info;
     const start = moment(info.onset).tz(timezone);
     const end = moment(info.expires).tz(timezone);
-    const startFormatted = start
-      .locale(locale)
-      .format(`${weekdayAbbreviationFormat} ${dateFormat} ${timeFormat}`);
+    const startFormatted = `${start.formatDateTime(
+        'weekdayAbbreviationAndDate',
+        locale
+      )} ${start.formatDateTime('time', locale, clockType)}`;
 
-    const endFormatted = end
-      .locale(locale)
-      .format(
-        start.isSame(end, 'day')
-          ? timeFormat
-          : `${weekdayAbbreviationFormat} ${dateFormat} ${timeFormat}`
-      );
+    const endFormatted = start.isSame(end, 'day')
+      ? end.formatDateTime('time', locale, clockType)
+      : `${end.formatDateTime(
+        'weekdayAbbreviationAndDate',
+        locale
+      )} ${end.formatDateTime('time', locale, clockType)}`;
+
     return `${startFormatted} - ${endFormatted}`;
   });
 

--- a/src/components/warnings/cap/WarningBlock.tsx
+++ b/src/components/warnings/cap/WarningBlock.tsx
@@ -39,9 +39,6 @@ function WarningBlock({
   const scrollViewRef = useRef<ScrollView>(null);
   const { i18n } = useTranslation();
   const locale = i18n.language;
-  const weekdayAbbreviationFormat = locale === 'en' ? 'ddd' : 'dd';
-  const dateFormat = locale === 'en' ? 'D MMM' : 'D.M.';
-  const timeFormat = clockType === 12 ? 'h.mm a' : 'HH.mm';
 
   const sortedWarnings = useMemo(() => [...warnings].sort((a, b) => {
     const aInfo = Array.isArray(a.info) ? selectCapInfoByLanguage(a.info, locale) : a.info;
@@ -152,15 +149,13 @@ function WarningBlock({
     }
 
     return intervals.map(({ onset, expiry }) => {
-      const onsetFormatted = onset
-        .locale(locale)
-        .format(`${weekdayAbbreviationFormat} ${dateFormat}`);
+      const onsetFormatted = onset.formatDateTime('weekdayAbbreviationAndDate', locale);
 
       if (onset.isSame(expiry, 'day')) return onsetFormatted;
 
       const expiryFormatted = expiry
         .locale(locale)
-        .format(`${weekdayAbbreviationFormat} ${dateFormat}`);
+        .formatDateTime('weekdayAbbreviationAndDate', locale);;
       return `${onsetFormatted} - ${expiryFormatted}`;
     });
   };
@@ -172,17 +167,17 @@ function WarningBlock({
     const info = Array.isArray(warning.info) ? warning.info[0] : warning.info;
     const start = moment(info.onset).tz(defaultLocation.timezone);
     const end = moment(info.expires).tz(defaultLocation.timezone);
-    const startFormatted = start
-      .locale(locale)
-      .format(`${weekdayAbbreviationFormat} ${dateFormat} ${timeFormat}`);
+    const startFormatted = `${start.formatDateTime(
+        'weekdayAbbreviationAndDate',
+        locale
+      )} ${start.formatDateTime('time', locale, clockType)}`;
 
-    const endFormatted = end
-      .locale(locale)
-      .format(
-        start.isSame(end, 'day')
-          ? timeFormat
-          : `${weekdayAbbreviationFormat} ${dateFormat} ${timeFormat}`
-      );
+    const endFormatted = start.isSame(end, 'day')
+      ? end.formatDateTime('time', locale, clockType)
+      : `${end.formatDateTime(
+        'weekdayAbbreviationAndDate',
+        locale
+      )} ${end.formatDateTime('time', locale, clockType)}`;
     return `${startFormatted} - ${endFormatted}`;
   });
 

--- a/src/components/weather/ForecastPanelWithVerticalLayout.tsx
+++ b/src/components/weather/ForecastPanelWithVerticalLayout.tsx
@@ -112,11 +112,7 @@ const ForecastPanelWithVerticalLayout: React.FC<ForecastPanelProps> = ({
 
   const forecastLastUpdated = {
     time: forecastLastUpdatedMoment
-      ? forecastLastUpdatedMoment.format(
-          `${locale === 'en' ? 'D MMM' : 'D.M.'} ${
-            clockType === 12 ? 'h:mm a' : 'HH:mm'
-          }`
-        )
+      ? forecastLastUpdatedMoment.formatDateTime('dateTime', locale, clockType)
       : undefined,
     ageCheck: forecastAge > (ageWarning ?? 720) * 60 * 1000,
   };

--- a/src/components/weather/MeteorologistSnapshot.tsx
+++ b/src/components/weather/MeteorologistSnapshot.tsx
@@ -42,11 +42,10 @@ const MeteorologistSnapshot: React.FC<MeteorologistSnapshotProps> = ({
   clockType,
   gridLayout,
 }) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const insets = useSafeAreaInsets();
   const { dark, colors } = useTheme() as CustomTheme;
   const colorMode = dark ? 'dark' : 'light';
-  const timeFormat = clockType === 12 ? 'D.M.YYYY h.mm a' : 'D.M.YYYY HH:mm';
   const marginLeft = gridLayout ? 8 : insets.left + 16;
   const marginRight = gridLayout ? insets.right : insets.right + 16;
   const minHeight = gridLayout ? 160 : 150;
@@ -103,7 +102,7 @@ const MeteorologistSnapshot: React.FC<MeteorologistSnapshotProps> = ({
         <Text
           accessibilityLabel={formatAccessibleDateTime(updatedMoment, t, clockType === 24)}
           style={[styles.updated, { color: colors.primaryText }]}>
-          { updatedMoment.format(timeFormat) }
+          { updatedMoment.formatDateTime('longDateTime', i18n.language, clockType) }
         </Text>
         <Text style={[styles.text, { color: colors.primaryText }]}>{snapshot.text}</Text>
       </View>

--- a/src/components/weather/forecast/ModalContent.tsx
+++ b/src/components/weather/forecast/ModalContent.tsx
@@ -9,7 +9,6 @@ import { State } from '@store/types';
 import { CustomTheme } from '@assets/colors';
 import { selectForecastByDay } from '@store/forecast/selectors';
 import ModalForecast from './ModalForecast';
-import { uppercaseFirst } from '@utils/helpers';
 import Icon from '@assets/Icon';
 import Text from '@components/common/AppText';
 import CloseButton from '@components/common/CloseButton';
@@ -49,9 +48,7 @@ const DailyModal: React.FC<ModalContentProps> = ({
   const { fontScale } = useWindowDimensions();
   const { t, i18n } = useTranslation('forecast');
   const { colors } = useTheme() as CustomTheme;
-  const largeFonts = fontScale >= 1.5;
   const iconSize = Math.min(fontScale * 22, 44);
-  const dateFormat = largeFonts ? 'dd D.M.' : 'dddd, D.M.';
 
   return (
     <View style={styles.container}>
@@ -77,7 +74,7 @@ const DailyModal: React.FC<ModalContentProps> = ({
             accessibilityRole="header"
             numberOfLines={1}
             style={[styles.text, styles.bold, styles.headerText, { color: colors.primaryText }]}>
-            {uppercaseFirst(moment(timeStamp).locale(i18n.language).format(dateFormat))}
+            {moment(timeStamp).formatDateTime('longDate', i18n.language)}
           </Text>
           <View accessible>
             <Icon

--- a/src/components/weather/forecast/Vertical10DaysForecast.tsx
+++ b/src/components/weather/forecast/Vertical10DaysForecast.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Modal from 'react-native-modal';
-import moment from 'moment';
+import moment from '@utils/moment';
 import { useTheme } from '@react-navigation/native';
 import { useTranslation } from 'react-i18next';
 import { connect, ConnectedProps } from 'react-redux';
@@ -27,7 +27,7 @@ import { State } from '@store/types';
 import { selectForecastInvalidData, selectDisplayParams } from '@store/forecast/selectors';
 
 import Icon from '@components/common/ScalableIcon';
-import { formatAccessibleDate, formatAccessibleTemperature, uppercaseFirst } from '@utils/helpers';
+import { formatAccessibleDate, formatAccessibleTemperature } from '@utils/helpers';
 import ModalContent from './ModalContent';
 import { trackMatomoEvent } from '@utils/matomo';
 import { REGULAR_FONT, BOLD_FONT } from '@assets/constants';
@@ -202,8 +202,6 @@ const Vertical10DaysForecast: React.FC<DaySelectorListProps> = ({
         converter(precipitationUnit, totalPrecipitation)
       );
 
-    const weekdayAbbreviationFormat = locale === 'en' ? 'ddd' : 'dd';
-    const dateFormat = locale === 'en' ? 'D MMM' : 'D.M.';
     const symbolSize = Math.min(64, fontScale * 44);
     const rowHeight = fontScale ? 80 : 70;
 
@@ -230,10 +228,10 @@ const Vertical10DaysForecast: React.FC<DaySelectorListProps> = ({
               accessibilityLabel={formatAccessibleDate(stepMoment, false)}
               style={styles.day}>
               <Text style={[styles.text, styles.bold, { color: colors.primaryText }]}>
-                { uppercaseFirst(stepMoment.format(weekdayAbbreviationFormat)) }
+                { stepMoment.formatDateTime('weekdayAbbreviation', locale) }
               </Text>
               <Text maxFontSizeMultiplier={1.3} style={[styles.text, { color: colors.primaryText }]}>
-                {stepMoment.format(dateFormat)}
+                {stepMoment.formatDateTime('date', locale)}
               </Text>
             </View>
             <View accessible accessibilityLabel={t(`symbols:${smartSymbol}`)}>

--- a/src/components/weather/observation/Latest.tsx
+++ b/src/components/weather/observation/Latest.tsx
@@ -48,18 +48,17 @@ const Latest: React.FC<LatestProps> = ({
   const locale = i18n.language;
   const { parameters } = Config.get('weather').observation;
   const decimalSeparator = locale === 'en' ? '.' : ',';
-  const weekdayAbbreviationFormat = locale === 'en' ? 'ddd' : 'dd';
-  const dateFormat =
-    clockType === 12
-      ? `${locale === 'en' ? 'D MMM' : 'D.M.'} [${t('at')}] h:mm a`
-      : `D.M. [${t('at')}] HH:mm`;
-
   const latestObservation = getLatestObservationAvoidingMissingValues(data);
 
   if (!latestObservation) return null;
 
   const observationMoment = moment(latestObservation.epochtime * 1000).locale(locale);
-  const latestObservationTime = observationMoment.format(`${weekdayAbbreviationFormat} ${dateFormat}`);
+  const latestObservationTime = `${observationMoment.formatDateTime(
+    'weekdayAbbreviation',
+    i18n.language
+  )} ${observationMoment.formatDateTime('date', i18n.language)} ${t(
+    'at'
+  )} ${observationMoment.formatDateTime('time', i18n.language, clockType)}`;
   const accessibleObservationTime = formatAccessibleDateTime(observationMoment, t, clockType === 24, false);
 
   const hoursSinceLatestObservation =

--- a/src/components/weather/observation/List.tsx
+++ b/src/components/weather/observation/List.tsx
@@ -363,8 +363,7 @@ const List: React.FC<ListProps> = ({
               { color: colors.hourListText },
             ]}>
             {moment(data[0].epochtime * 1000)
-              .locale(locale)
-              .format(locale === 'en' ? `dddd D MMM` : `dddd D.M.`)}
+              .formatDateTime('weekdayAndDate', locale)}
           </Text>
         )}
       </View>
@@ -408,9 +407,7 @@ const List: React.FC<ListProps> = ({
         const time = moment(timeStep.epochtime * 1000).locale(locale);
         const previousTime = moment(arr?.[i - 1]?.epochtime * 1000);
 
-        const timeToDisplay = time.format(
-          clockType === 12 ? 'h.mm a' : 'HH.mm'
-        );
+        const timeToDisplay = time.formatDateTime('time', locale, clockType);
 
         return (
           <View key={timeStep.epochtime}>
@@ -430,9 +427,7 @@ const List: React.FC<ListProps> = ({
                     styles.capitalize,
                     { color: colors.hourListText },
                   ]}>
-                  {time.format(
-                    locale === 'en' ? 'dddd D MMM' : `dddd D.M.`
-                  )}
+                  {time.formatDateTime('weekdayAndDate', locale)}
                 </Text>
               </View>
             )}

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -265,6 +265,24 @@ interface MarkdownSettings {
   accessibility: boolean;
 }
 
+interface DateTimeFormats {
+  date: string;
+  longDate: string;
+  dateYear: string;
+  dateTime: string;
+  longDateTime: string;
+  time: string;
+  weekdayAbbreviation: string;
+  weekday: string;
+  weekdayAndDate: string;
+  weekdayAbbreviationAndDate: string;
+}
+
+interface DateTimeSettings {
+  default: DateTimeFormats;
+  locales?: Record<string, Partial<DateTimeFormats>>;
+}
+
 // TODO: how to handle errors. Add error categories to "actions" and then name -field can be error message content
 // for example: trackMatomoEvent('Error', 'Error loading forecast data', error.getMessage())
 // Events in Matomo have three dimension (category, action, name)
@@ -332,6 +350,7 @@ export interface ConfigType {
     showUnitSettings?: boolean;
     excludeUnits?: MeasurementUnit[];
     clockType: 12 | 24;
+    dateTime: DateTimeSettings;
     themes: Themes;
     verboseErrorMessages?: boolean;
     markdown?: MarkdownSettings;

--- a/src/utils/chart.ts
+++ b/src/utils/chart.ts
@@ -173,11 +173,8 @@ export const tickFormat = (
     return '';
   }
   if (daily || hour === 0) {
-    return `${capitalize(
-      time.format(locale === 'en' ? 'ddd' : 'dd')
-    )}\n${time.format(
-      locale === 'en' ? 'D MMM' : 'D.M.'
-    )}`;
+    return `${time.formatDateTime('weekdayAbbreviation', locale, clockType)}\n${time.formatDateTime(
+      'date', locale)}`;
   }
   return time.format(clockType === 12 ? 'h a' : 'HH');
 };

--- a/src/utils/moment.ts
+++ b/src/utils/moment.ts
@@ -1,0 +1,66 @@
+import moment from 'moment';
+import defaultConfig from '../../defaultConfig';
+
+export type DateTimeFormatType = keyof typeof defaultConfig.settings.dateTime.default;
+
+const { dateTime } = defaultConfig.settings;
+
+const findLocaleFormats = (locale?: string) => {
+  if (!locale) {
+    return undefined;
+  }
+
+  const normalizedLocale = locale.toLowerCase();
+  const baseLocale = normalizedLocale.split('-')[0];
+
+  return dateTime.locales?.[normalizedLocale] ?? dateTime.locales?.[baseLocale];
+};
+
+const uppercaseFirst = (str: string): string =>
+  str ? str[0].toUpperCase() + str.slice(1) : '';
+
+const resolveFormat = (
+  format: string
+): { format: string; uppercaseFirst: boolean } => ({
+  format: format.startsWith('U') ? format.slice(1) : format,
+  uppercaseFirst: format.startsWith('U'),
+});
+
+const formatWithClockType = (format: string, clockType: 12 | 24 = 24): string =>
+  clockType === 12 ? format.replace(/H{1,2}[.:]mm/g, 'h:mm a') : format;
+
+export const getDateTimeFormat = (
+  type: DateTimeFormatType,
+  locale?: string
+): string => {
+  const localeFormats = findLocaleFormats(locale);
+
+  return localeFormats?.[type] ?? dateTime.default[type];
+};
+
+declare module 'moment' {
+  interface Moment {
+    formatDateTime(
+      type: DateTimeFormatType,
+      locale?: string,
+      clockType?: 12 | 24
+    ): string;
+  }
+}
+
+moment.fn.formatDateTime = function formatDateTime(
+  this: moment.Moment,
+  type: DateTimeFormatType,
+  locale?: string,
+  clockType?: 12 | 24
+): string {
+  const localeToUse = locale ?? this.locale();
+  const { format: formatWithoutPrefix, uppercaseFirst: shouldUppercaseFirst } =
+    resolveFormat(getDateTimeFormat(type, localeToUse));
+  const format = formatWithClockType(formatWithoutPrefix, clockType);
+  const formattedValue = this.clone().locale(localeToUse).format(format);
+
+  return shouldUppercaseFirst ? uppercaseFirst(formattedValue) : formattedValue;
+};
+
+export default moment;


### PR DESCRIPTION
Date and time settings can be added to DefaultConfig like this:

```
    dateTime: {
      default: {
        date: 'D.M.',
        dateYear: 'D.M.YYYY',
        longDate: 'Udddd, D.M.',
        time: 'HH:mm',
        dateTime: 'D.M. HH:mm',
        longDateTime: 'D.M.YYYY HH:mm',
        weekdayAbbreviation: 'Udd',
        weekday: 'Udddd',
        weekdayAndDate: 'dddd D.M.',
        weekdayAbbreviationAndDate: 'Udd D.M.',
      },
      locales: {
        en: {
          date: 'D MMM',
          dateTime: 'D MMM HH:mm',
          weekdayAbbreviation: 'Uddd',
          weekdayAndDate: 'Udddd D MMM',
          weekdayAbbreviationAndDate: 'Uddd D MMM',
        },
      }
    },
```

defaults are required, language specific settings are optional.

Only changed visible dates and times to use new configuration, didn't change dates and times in accessibility labels.

Closes #1371 