### PR TITLE
issue-1382: Added geojson and polygon simplification support for CAP warnings

### DIFF
--- a/__tests__/components/MapViewCap.test.tsx
+++ b/__tests__/components/MapViewCap.test.tsx
@@ -124,7 +124,7 @@ describe('MapView', () => {
         dates={[
           { time: new Date('2024-01-01T12:00:00Z').getTime(), weekday: 'Mon', date: '1 Jan', relativeDay: 'Today' },
         ]}
-        capData={undefined as any}
+        capData={undefined}
       />
     ).UNSAFE_getByType(ActivityIndicator)).toBeTruthy();
   });

--- a/__tests__/components/MapViewCap.test.tsx
+++ b/__tests__/components/MapViewCap.test.tsx
@@ -43,14 +43,14 @@ jest.mock('react-native-maps', () => {
       {children}
     </View>
   ));
-  const Polygon = ({ coordinates, fillColor }: any) => (
-    <View testID={`polygon-${fillColor}-${coordinates.length}`} />
+  const Geojson = ({ geojson, fillColor }: any) => (
+    <View testID={`geojson-${fillColor}-${geojson?.features?.length ?? 0}`} />
   );
 
   return {
     __esModule: true,
     default: MockMap,
-    Polygon,
+    Geojson,
   };
 });
 
@@ -124,7 +124,7 @@ describe('MapView', () => {
         dates={[
           { time: new Date('2024-01-01T12:00:00Z').getTime(), weekday: 'Mon', date: '1 Jan', relativeDay: 'Today' },
         ]}
-        capData={[]}
+        capData={undefined as any}
       />
     ).UNSAFE_getByType(ActivityIndicator)).toBeTruthy();
   });
@@ -157,10 +157,11 @@ describe('MapView', () => {
 
     expect(getByTestId('day-selector')).toBeTruthy();
     expect(getByTestId('warning-filter')).toBeTruthy();
-    expect(queryAllByTestId('polygon-#FFCB5F-4')).toHaveLength(1);
+    expect(queryAllByTestId('geojson-#FFCB5F-1')).toHaveLength(1);
 
     fireEvent.press(getByTestId('warning-filter'));
-    expect(queryAllByTestId('polygon-#FFCB5F-4')).toHaveLength(0);
+    expect(queryAllByTestId('geojson-#FFCB5F-1')).toHaveLength(0);
+    expect(queryAllByTestId('geojson-#FFCB5F-0')).toHaveLength(1);
 
     fireEvent.press(getByTestId('day-selector'));
   });

--- a/__tests__/utils/capPolygon.test.ts
+++ b/__tests__/utils/capPolygon.test.ts
@@ -1,0 +1,39 @@
+import { parseCapPolygon } from '@utils/capPolygon';
+
+describe('parseCapPolygon', () => {
+  test('parses coordinates separated by whitespace', () => {
+    expect(parseCapPolygon('60,24  60,25\n61,25\t61,24')).toEqual([
+      [24, 60],
+      [25, 60],
+      [25, 61],
+      [24, 61],
+      [24, 60],
+    ]);
+  });
+
+  test('excludes malformed and non-numeric coordinates', () => {
+    expect(
+      parseCapPolygon('60,24 invalid 60, 61,25 61,not-a-number 61,24')
+    ).toEqual([
+      [24, 60],
+      [25, 61],
+      [24, 61],
+      [24, 60],
+    ]);
+  });
+
+  test('closes the ring without simplifying when tolerance is undefined', () => {
+    const polygon = parseCapPolygon(
+      '60,24 60.0005,24.01 60,24.02 60.02,24.02 60.02,24'
+    );
+
+    expect(polygon).toEqual([
+      [24, 60],
+      [24.01, 60.0005],
+      [24.02, 60],
+      [24.02, 60.02],
+      [24, 60.02],
+      [24, 60],
+    ]);
+  });
+});

--- a/__tests__/utils/simplifyPolygon.test.ts
+++ b/__tests__/utils/simplifyPolygon.test.ts
@@ -1,0 +1,47 @@
+import { simplifyPolygon } from '@utils/simplifyPolygon';
+
+describe('simplifyPolygon', () => {
+  test('removes points less than one kilometer from the simplified edge', () => {
+    const ring: [number, number][] = [
+      [24, 60],
+      [24.01, 60.0005],
+      [24.02, 60],
+      [24.02, 60.02],
+      [24, 60.02],
+      [24, 60],
+    ];
+
+    const simplified = simplifyPolygon(ring, 1000);
+
+    expect(simplified).not.toContainEqual([24.01, 60.0005]);
+    expect(simplified.length).toBeLessThan(ring.length);
+    expect(simplified.length).toBeGreaterThanOrEqual(4);
+    expect(simplified[0]).toEqual(simplified[simplified.length - 1]);
+  });
+
+  test('keeps deviations larger than the tolerance', () => {
+    const ring: [number, number][] = [
+      [24, 60],
+      [24.01, 60.02],
+      [24.02, 60],
+      [24.02, 60.04],
+      [24, 60.04],
+      [24, 60],
+    ];
+
+    expect(simplifyPolygon(ring, 1000)).toContainEqual([24.01, 60.02]);
+  });
+
+  test('closes an open polygon ring', () => {
+    const ring: [number, number][] = [
+      [24, 60],
+      [25, 60],
+      [25, 61],
+      [24, 61],
+    ];
+
+    const simplified = simplifyPolygon(ring, 1000);
+
+    expect(simplified[0]).toEqual(simplified[simplified.length - 1]);
+  });
+});

--- a/src/components/warnings/cap/MapView.tsx
+++ b/src/components/warnings/cap/MapView.tsx
@@ -15,11 +15,8 @@ import {
   GRAY_8,
 } from '@assets/colors';
 import darkMapStyle from '@utils/dark_map_style.json';
+import { parseCapPolygon } from '@utils/capPolygon';
 import { getSeveritiesForDays } from '@utils/helpers';
-import {
-  GeoJsonPosition,
-  simplifyPolygon,
-} from '@utils/simplifyPolygon';
 import DaySelectorList from './DaySelectorList';
 import WarningTypeFiltersList from './WarningTypeFiltersList';
 import { selectLoading } from '@store/warnings/selectors';
@@ -116,35 +113,20 @@ const MapView: React.FC<MapViewProps> = ({
     dark && Platform.OS === 'android' ? darkMapStyle : [];
 
   const parsedCapData = useMemo(() => {
-    return capData
+    return applicableWarnings
       ?.map((warning) => {
         const info = Array.isArray(warning.info) ? warning.info[0] : warning.info;
         return {
-          identifier: warning.identifier,
           event: info.event,
           severity: info?.severity,
           polygons: [info.area.polygon]
             .flat()
             .filter(Boolean)
-            .map((polygon) => polygon
-              ?.split(' ')
-              .map<GeoJsonPosition>((coordinates) => {
-                const parts = coordinates.split(',').map(Number);
-                return [parts[1], parts[0]]; // GeoJSON vaatii [longitude, latitude] -järjestyksen
-              }))
-            .map((polygon) => polygonAccuracy === undefined
-              ? polygon
-              : simplifyPolygon(polygon, polygonAccuracy)
-            ),
+            .map((polygon) => parseCapPolygon(polygon, polygonAccuracy)),
         };
       })
       || [];
-  }, [capData, polygonAccuracy]);
-
-  const activeWarningIds = useMemo(
-    () => new Set(applicableWarnings?.map((w) => w.identifier) || []),
-    [applicableWarnings]
-  );
+  }, [applicableWarnings, polygonAccuracy]);
 
   const geojsonCollections = useMemo(() => {
     const collections: Record<string, any> = {
@@ -153,14 +135,13 @@ const MapView: React.FC<MapViewProps> = ({
       Extreme: { type: 'FeatureCollection', features: [] },
     };
 
-    parsedCapData.forEach(({ identifier, event, severity, polygons }) => {
+    parsedCapData.forEach(({ event, severity, polygons }) => {
       const isHidden =
-        !activeWarningIds.has(identifier) ||
         !!selectedFilters.find(
           (filter) => filter.event === event && filter.severity === severity
         );
 
-      // Jätetään piilotetut kokonaan pois GeoJSON:ista
+      // Exclude hidden warnings from GeoJSON
       if (isHidden || !severity || !SEVERITIES.includes(severity as Severity)) return;
 
       polygons.forEach((coords) => {
@@ -169,7 +150,7 @@ const MapView: React.FC<MapViewProps> = ({
             type: 'Feature',
             geometry: {
               type: 'Polygon',
-              coordinates: [coords], // GeoJSON Polygonia varten taulukon sisällä
+              coordinates: [coords], // GeoJSON polygon coordinates require an array of rings
             },
             properties: {},
           });
@@ -178,7 +159,7 @@ const MapView: React.FC<MapViewProps> = ({
     });
 
     return collections;
-  }, [parsedCapData, activeWarningIds, selectedFilters]);
+  }, [parsedCapData, selectedFilters]);
 
   const handleWarningTypePress = (warning: CapWarning) => {
     const info = Array.isArray(warning.info) ? warning.info[0] : warning.info;

--- a/src/components/warnings/cap/MapView.tsx
+++ b/src/components/warnings/cap/MapView.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { View, StyleSheet, Platform, ActivityIndicator } from 'react-native';
-import Map, { Polygon } from 'react-native-maps';
+import Map, { Geojson } from 'react-native-maps';
 import { connect, ConnectedProps } from 'react-redux';
 import moment from 'moment-timezone';
 
@@ -16,6 +16,10 @@ import {
 } from '@assets/colors';
 import darkMapStyle from '@utils/dark_map_style.json';
 import { getSeveritiesForDays } from '@utils/helpers';
+import {
+  GeoJsonPosition,
+  simplifyPolygon,
+} from '@utils/simplifyPolygon';
 import DaySelectorList from './DaySelectorList';
 import WarningTypeFiltersList from './WarningTypeFiltersList';
 import { selectLoading } from '@store/warnings/selectors';
@@ -106,32 +110,75 @@ const MapView: React.FC<MapViewProps> = ({
   const mapRef = useRef<Map>(null);
   const { colors, dark } = useTheme() as CustomTheme;
   const capViewSettings = Config.get('warnings')?.capViewSettings;
+  const polygonAccuracy = capViewSettings?.polygonAccuracy;
 
   const darkGoogleMapsStyle =
     dark && Platform.OS === 'android' ? darkMapStyle : [];
 
-  const polygonArray =
-    applicableWarnings
+  const parsedCapData = useMemo(() => {
+    return capData
       ?.map((warning) => {
         const info = Array.isArray(warning.info) ? warning.info[0] : warning.info;
         return {
           identifier: warning.identifier,
           event: info.event,
           severity: info?.severity,
-          polygons: [info.area.polygon].flat().map((polygon, index) => ({
-            key: `${warning.identifier}-${index}`,
-            latLng: polygon
+          polygons: [info.area.polygon]
+            .flat()
+            .filter(Boolean)
+            .map((polygon) => polygon
               ?.split(' ')
-              .map((coordinates) =>
-                coordinates.split(',').map((coordinate) => Number(coordinate))
-              )
-              .map((pair) => ({
-                latitude: pair[0],
-                longitude: pair[1],
-              })),
-          })),
-      }})
-      .flat() || [];
+              .map<GeoJsonPosition>((coordinates) => {
+                const parts = coordinates.split(',').map(Number);
+                return [parts[1], parts[0]]; // GeoJSON vaatii [longitude, latitude] -järjestyksen
+              }))
+            .map((polygon) => polygonAccuracy === undefined
+              ? polygon
+              : simplifyPolygon(polygon, polygonAccuracy)
+            ),
+        };
+      })
+      || [];
+  }, [capData, polygonAccuracy]);
+
+  const activeWarningIds = useMemo(
+    () => new Set(applicableWarnings?.map((w) => w.identifier) || []),
+    [applicableWarnings]
+  );
+
+  const geojsonCollections = useMemo(() => {
+    const collections: Record<string, any> = {
+      Moderate: { type: 'FeatureCollection', features: [] },
+      Severe: { type: 'FeatureCollection', features: [] },
+      Extreme: { type: 'FeatureCollection', features: [] },
+    };
+
+    parsedCapData.forEach(({ identifier, event, severity, polygons }) => {
+      const isHidden =
+        !activeWarningIds.has(identifier) ||
+        !!selectedFilters.find(
+          (filter) => filter.event === event && filter.severity === severity
+        );
+
+      // Jätetään piilotetut kokonaan pois GeoJSON:ista
+      if (isHidden || !severity || !SEVERITIES.includes(severity as Severity)) return;
+
+      polygons.forEach((coords) => {
+        if (coords && coords.length >= 3) {
+          collections[severity as Severity].features.push({
+            type: 'Feature',
+            geometry: {
+              type: 'Polygon',
+              coordinates: [coords], // GeoJSON Polygonia varten taulukon sisällä
+            },
+            properties: {},
+          });
+        }
+      });
+    });
+
+    return collections;
+  }, [parsedCapData, activeWarningIds, selectedFilters]);
 
   const handleWarningTypePress = (warning: CapWarning) => {
     const info = Array.isArray(warning.info) ? warning.info[0] : warning.info;
@@ -184,27 +231,18 @@ const MapView: React.FC<MapViewProps> = ({
         moveOnMarkerPress={false}
         scrollEnabled={capViewSettings?.mapScrollEnabled}
         zoomEnabled={capViewSettings?.mapZoomEnabled}>
-        {polygonArray?.length > 0 &&
-          polygonArray
-            .filter(
-              ({ event, severity }) =>
-                !selectedFilters.find(
-                  (filter) =>
-                    filter.event === event && filter.severity === severity
-                )
-            )
-            .map(({ severity, polygons }) =>
-              polygons.map((polygon) => (
-                <Polygon
-                  coordinates={polygon.latLng}
-                  key={polygon.key}
-                  fillColor={SEVERITY_COLORS[severity]}
-                  zIndex={SEVERITIES.indexOf(severity)}
-                />
-              ))
-            )}
+        {SEVERITIES.map((severity, index) => (
+          <Geojson
+            key={severity}
+            geojson={geojsonCollections[severity]}
+            fillColor={SEVERITY_COLORS[severity]}
+            strokeColor={colors.primaryText}
+            strokeWidth={1}
+            zIndex={index}
+          />
+        ))}
       </Map>
-      { loading ? (
+      { loading && !capData ? (
         Platform.OS === 'android' ?
           <ActivityIndicator size="large" color={colors.primary} />
           : (

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -131,6 +131,7 @@ interface CapViewSettings {
   severityBackgroundInSymbol?: boolean;
   hideLongArealist?: boolean;
   useRelativeDays?: boolean;
+  polygonAccuracy?: number; // in meters, if not set original polygon is used
 }
 
 interface Warnings {

--- a/src/utils/capPolygon.ts
+++ b/src/utils/capPolygon.ts
@@ -1,0 +1,33 @@
+import {
+  GeoJsonPosition,
+  simplifyPolygon,
+} from '@utils/simplifyPolygon';
+
+export const parseCapPolygon = (
+  polygon: string,
+  toleranceMeters?: number
+): GeoJsonPosition[] => {
+  const positions = polygon
+    .trim()
+    .split(/\s+/)
+    .reduce<GeoJsonPosition[]>((validPositions, coordinate) => {
+      const parts = coordinate.split(',');
+
+      if (parts.length !== 2 || parts.some((part) => part.trim() === '')) {
+        return validPositions;
+      }
+
+      const latitude = Number(parts[0]);
+      const longitude = Number(parts[1]);
+
+      if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+        return validPositions;
+      }
+
+      validPositions.push([longitude, latitude]);
+      return validPositions;
+    }, []);
+
+  // A zero tolerance closes the ring without simplifying its geometry.
+  return simplifyPolygon(positions, toleranceMeters ?? 0);
+};

--- a/src/utils/simplifyPolygon.ts
+++ b/src/utils/simplifyPolygon.ts
@@ -1,0 +1,121 @@
+export type GeoJsonPosition = [longitude: number, latitude: number];
+
+type ProjectedPosition = [x: number, y: number];
+
+const EARTH_RADIUS_METERS = 6_371_008.8;
+
+const positionsEqual = (
+  first: GeoJsonPosition,
+  second: GeoJsonPosition
+): boolean => first[0] === second[0] && first[1] === second[1];
+
+const squaredSegmentDistance = (
+  point: ProjectedPosition,
+  start: ProjectedPosition,
+  end: ProjectedPosition
+): number => {
+  let x = start[0];
+  let y = start[1];
+  let dx = end[0] - x;
+  let dy = end[1] - y;
+
+  if (dx !== 0 || dy !== 0) {
+    const position =
+      ((point[0] - x) * dx + (point[1] - y) * dy) / (dx * dx + dy * dy);
+
+    if (position > 1) {
+      x = end[0];
+      y = end[1];
+    } else if (position > 0) {
+      x += dx * position;
+      y += dy * position;
+    }
+  }
+
+  dx = point[0] - x;
+  dy = point[1] - y;
+
+  return dx * dx + dy * dy;
+};
+
+const simplifyLine = (
+  positions: ProjectedPosition[],
+  squaredTolerance: number
+): number[] => {
+  const lastIndex = positions.length - 1;
+  const retained = new Uint8Array(positions.length);
+  const ranges: Array<[number, number]> = [[0, lastIndex]];
+
+  retained[0] = 1;
+  retained[lastIndex] = 1;
+
+  while (ranges.length > 0) {
+    const [firstIndex, finalIndex] = ranges.pop() as [number, number];
+    let furthestIndex = 0;
+    let furthestDistance = squaredTolerance;
+
+    for (let index = firstIndex + 1; index < finalIndex; index += 1) {
+      const distance = squaredSegmentDistance(
+        positions[index],
+        positions[firstIndex],
+        positions[finalIndex]
+      );
+
+      if (distance > furthestDistance) {
+        furthestIndex = index;
+        furthestDistance = distance;
+      }
+    }
+
+    if (furthestIndex !== 0) {
+      retained[furthestIndex] = 1;
+      ranges.push([firstIndex, furthestIndex], [furthestIndex, finalIndex]);
+    }
+  }
+
+  return Array.from(retained)
+    .map((value, index) => (value ? index : -1))
+    .filter((index) => index >= 0);
+};
+
+const closeRing = (positions: GeoJsonPosition[]): GeoJsonPosition[] => {
+  if (positions.length === 0) return positions;
+  if (positionsEqual(positions[0], positions[positions.length - 1])) {
+    return positions;
+  }
+  return [...positions, positions[0]];
+};
+
+/**
+ * Simplifies a GeoJSON polygon ring using a tolerance measured in meters.
+ */
+export const simplifyPolygon = (
+  ring: GeoJsonPosition[],
+  toleranceMeters: number
+): GeoJsonPosition[] => {
+  if (ring.length < 3) return ring;
+
+  const openRing = positionsEqual(ring[0], ring[ring.length - 1])
+    ? ring.slice(0, -1)
+    : ring;
+
+  if (openRing.length <= 3 || toleranceMeters <= 0) return closeRing(openRing);
+
+  const referenceLatitude =
+    openRing.reduce((sum, position) => sum + position[1], 0) / openRing.length;
+  const longitudeScale = Math.cos((referenceLatitude * Math.PI) / 180);
+  const projectedPositions: ProjectedPosition[] = openRing.map(
+    ([longitude, latitude]) => [
+      EARTH_RADIUS_METERS * (longitude * Math.PI / 180) * longitudeScale,
+      EARTH_RADIUS_METERS * (latitude * Math.PI / 180),
+    ]
+  );
+  const retainedIndexes = simplifyLine(
+    projectedPositions,
+    toleranceMeters * toleranceMeters
+  );
+  const simplifiedRing = retainedIndexes.map((index) => openRing[index]);
+
+  // A valid polygon needs at least three distinct positions.
+  return closeRing(simplifiedRing.length >= 3 ? simplifiedRing : openRing);
+};


### PR DESCRIPTION
Polygon simplification can be configured in `capViewSettings`, for example

`polygonAccuracy: 250,`

Uses 250 meter accuracy, if value is not set then original polygon is used.

Closes #1382 