### PR TITLE
issue-1384: Added sortAreas and removeDuplicateAreas CAP settings

### DIFF
--- a/__tests__/components/WarningItemCap.test.tsx
+++ b/__tests__/components/WarningItemCap.test.tsx
@@ -4,6 +4,8 @@ import { render } from '@testing-library/react-native';
 import WarningItem from '../../src/components/warnings/cap/WarningItem';
 
 const mockConfigGet = jest.fn();
+let mockSortAreas = false;
+let mockRemoveDuplicateAreas = false;
 const mockIcon = jest.fn((props) => {
   const { Text } = require('react-native');
   return <Text {...props} testID={`icon-${props.name}`}>icon</Text>;
@@ -64,12 +66,16 @@ describe('WarningItem', () => {
   beforeEach(() => {
     mockConfigGet.mockReset();
     mockIcon.mockClear();
+    mockSortAreas = false;
+    mockRemoveDuplicateAreas = false;
     mockConfigGet.mockImplementation((key: string) => {
       if (key === 'warnings') {
         return {
           capViewSettings: {
             warningBlockWarningCountEnabled: true,
             hideLongArealist: true,
+            sortAreas: mockSortAreas,
+            removeDuplicateAreas: mockRemoveDuplicateAreas,
           },
         };
       }
@@ -130,5 +136,53 @@ describe('WarningItem', () => {
 
     expect(getByText('Heavy rain expected')).toBeTruthy();
     expect(getByText('Helsinki')).toBeTruthy();
+  });
+
+  it('sorts areasDescription alphabetically when configured', () => {
+    mockSortAreas = true;
+    const warning = {
+      info: {
+        event: 'Rain',
+        severity: 'Moderate',
+        area: { areaDesc: 'Helsinki' },
+        description: 'Heavy rain expected',
+      },
+    } as any;
+
+    const { getByText } = render(
+      <WarningItem
+        areasDescription="Vantaa, Espoo, Helsinki"
+        warning={warning}
+        timespan="Tue 2 Jan"
+        includeSeverityBars={false}
+        includeArrow={false}
+      />
+    );
+
+    expect(getByText('Espoo, Helsinki, Vantaa')).toBeTruthy();
+  });
+
+  it('removes duplicate areas when configured', () => {
+    mockRemoveDuplicateAreas = true;
+    const warning = {
+      info: {
+        event: 'Rain',
+        severity: 'Moderate',
+        area: { areaDesc: 'Helsinki' },
+        description: 'Heavy rain expected',
+      },
+    } as any;
+
+    const { getByText } = render(
+      <WarningItem
+        areasDescription="Helsinki, Espoo, Helsinki"
+        warning={warning}
+        timespan="Tue 2 Jan"
+        includeSeverityBars={false}
+        includeArrow={false}
+      />
+    );
+
+    expect(getByText('Helsinki, Espoo')).toBeTruthy();
   });
 });

--- a/src/components/warnings/cap/WarningItem.tsx
+++ b/src/components/warnings/cap/WarningItem.tsx
@@ -53,7 +53,27 @@ const WarningItem: React.FC<WarningItemProps> = ({
     .toUpperCase()
     .concat(info.area.areaDesc.substring(1));
 
-  const areaList = areasDescription || areaDesc;
+  const formatAreasDescription = (description: string): string => {
+    let areas = description.split(',').map((area) => area.trim());
+
+    if (capViewSettings?.removeDuplicateAreas === true) {
+      areas = [...new Set(areas)];
+    }
+
+    if (capViewSettings?.sortAreas === true) {
+      areas.sort((areaA, areaB) => areaA.localeCompare(areaB, i18n.language));
+    }
+
+    return areas.join(', ');
+  };
+
+  const shouldFormatAreas =
+    areasDescription &&
+    (capViewSettings?.sortAreas === true ||
+      capViewSettings?.removeDuplicateAreas === true);
+  const areaList = shouldFormatAreas
+    ? formatAreasDescription(areasDescription)
+    : areasDescription || areaDesc;
   const areaCount = areaList.split(',').length;
 
   return (

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -131,6 +131,8 @@ interface CapViewSettings {
   severityBackgroundInSymbol?: boolean;
   hideLongArealist?: boolean;
   useRelativeDays?: boolean;
+  sortAreas?: boolean;
+  removeDuplicateAreas?: boolean;
 }
 
 interface Warnings {


### PR DESCRIPTION
Allows to sort area names and remove duplicate area names from warning headers.

Closes #1384 