### PR TITLE
issue-1370: Added sending smartmet-session-id from wms requests

### DIFF
--- a/__tests__/components/MlMapView.test.tsx
+++ b/__tests__/components/MlMapView.test.tsx
@@ -10,6 +10,7 @@ const mockSelectTimeZone = jest.fn((state: any) => state.mock.timezone);
 const mockSelectDisplayLocation = jest.fn((state: any) => state.mock.displayLocation);
 const mockSelectOverlay = jest.fn((state: any) => state.mock.overlay);
 const mockSelectActiveOverlay = jest.fn((state: any) => state.mock.activeOverlay);
+const mockSelectSessionId = jest.fn((state: any) => state.mock.sessionId);
 const mockUpdateOverlays = jest.fn((...args: any[]) => ({
   type: 'MAP/UPDATE_OVERLAYS',
   payload: { overlayId: args[0], library: args[1] },
@@ -19,6 +20,8 @@ const mockGetDistance = jest.fn();
 const mockUseIsFocused = jest.fn();
 const mockUseReloader = jest.fn();
 const mockConfigGet = jest.fn();
+const mockAddHeader = jest.fn();
+const mockRemoveHeader = jest.fn();
 const mockWMSOverlay = jest.fn((props) => (
   <Text testID={`wms-overlay-${props.library}`}>wms</Text>
 ));
@@ -50,6 +53,10 @@ jest.mock('@store/map/selectors', () => ({
   selectDisplayLocation: (state: any) => mockSelectDisplayLocation(state),
   selectOverlay: (state: any) => mockSelectOverlay(state),
   selectActiveOverlay: (state: any) => mockSelectActiveOverlay(state),
+}));
+
+jest.mock('@store/settings/selectors', () => ({
+  selectSessionId: (state: any) => mockSelectSessionId(state),
 }));
 
 jest.mock('@store/map/actions', () => ({
@@ -147,6 +154,10 @@ jest.mock('@maplibre/maplibre-react-native', () => {
     Map,
     Camera,
     ViewAnnotation,
+    TransformRequestManager: {
+      addHeader: (...args: any[]) => mockAddHeader(...args),
+      removeHeader: (...args: any[]) => mockRemoveHeader(...args),
+    },
   };
 });
 
@@ -193,6 +204,7 @@ describe('MlMapView', () => {
         overlay: { type: 'WMS', step: 60 },
         activeOverlay: 3,
         timezone: 'Europe/Helsinki',
+        sessionId: 1234567,
       },
     });
 
@@ -209,6 +221,12 @@ describe('MlMapView', () => {
     );
 
     expect(mockUpdateOverlays).toHaveBeenCalledWith(3, 'maplibre');
+    expect(mockAddHeader).toHaveBeenCalledWith({
+      id: 'smartmet-session-cookie',
+      match: '(?i)(?:[?&])request=GetMap(?:&|$)',
+      name: 'Cookie',
+      value: 'smartmet-session-id=1234567',
+    });
 
     await act(async () => {
       lastMapProps.onDidFinishLoadingStyle();
@@ -235,6 +253,7 @@ describe('MlMapView', () => {
         overlay: { type: 'Timeseries', step: 60 },
         activeOverlay: 3,
         timezone: 'Europe/Helsinki',
+        sessionId: 1234567,
       },
     });
 
@@ -301,5 +320,31 @@ describe('MlMapView', () => {
       'Map',
       'Open info panel'
     );
+  });
+
+  it('removes the WMS session cookie header on unmount', () => {
+    const store = createStore({
+      mock: {
+        currentLocation: { lat: 60.1699, lon: 24.9384 },
+        displayLocation: true,
+        overlay: undefined,
+        activeOverlay: undefined,
+        timezone: 'Europe/Helsinki',
+        sessionId: 7654321,
+      },
+    });
+
+    const { unmount } = render(
+      <Provider store={store as any}>
+        <MlMapView
+          infoSheetRef={{ current: null }}
+          mapLayersSheetRef={{ current: null }}
+        />
+      </Provider>
+    );
+
+    unmount();
+
+    expect(mockRemoveHeader).toHaveBeenCalledWith('smartmet-session-cookie');
   });
 });

--- a/__tests__/store/settings.test.ts
+++ b/__tests__/store/settings.test.ts
@@ -1,4 +1,7 @@
-import reducer from '@store/settings/reducer';
+import reducer, {
+  generateSessionId,
+  settingsPersist,
+} from '@store/settings/reducer';
 import * as actions from '@store/settings/actions';
 import * as selectors from '@store/settings/selectors';
 import * as types from '@store/settings/types';
@@ -41,7 +44,13 @@ describe('settings reducer', () => {
     };
     expect(
       reducer(
-        { units, theme: 'automatic', clockType: 24, mapLibrary: 'react-native-maps' },
+        {
+          units,
+          theme: 'automatic',
+          clockType: 24,
+          mapLibrary: 'react-native-maps',
+          sessionId: 123,
+        },
         {
           type: types.UPDATE_UNITS,
           units: {
@@ -68,6 +77,7 @@ describe('settings reducer', () => {
       },
       clockType: 24,
       mapLibrary: 'react-native-maps',
+      sessionId: 123,
     });
   });
 
@@ -80,6 +90,7 @@ describe('settings reducer', () => {
       theme: 'light',
       clockType: undefined,
       mapLibrary: 'react-native-maps',
+      sessionId: expect.any(Number),
     });
   });
 
@@ -92,6 +103,7 @@ describe('settings reducer', () => {
       theme: undefined,
       clockType: 24,
       mapLibrary: 'react-native-maps',
+      sessionId: expect.any(Number),
     });
   });
 
@@ -106,6 +118,7 @@ describe('settings reducer', () => {
       theme: undefined,
       clockType: undefined,
       mapLibrary: 'maplibre',
+      sessionId: expect.any(Number),
     });
   });
 
@@ -115,6 +128,7 @@ describe('settings reducer', () => {
         clockType: 24,
         mapLibrary: 'maplibre',
         theme: 'dark',
+        sessionId: 456,
         units: {
           temperature: {
             unitAbb: 'C',
@@ -130,6 +144,35 @@ describe('settings reducer', () => {
     expect(selectors.selectTheme(state)).toBe('dark');
     expect(selectors.selectClockType(state)).toBe(24);
     expect(selectors.selectMapLibrary(state)).toBe('maplibre');
+    expect(selectors.selectSessionId(state)).toBe(456);
+  });
+
+  it('generates a session id within the allowed range', () => {
+    const randomSpy = jest
+      .spyOn(Math, 'random')
+      .mockReturnValueOnce(0)
+      .mockReturnValueOnce(0.999999999);
+
+    expect(generateSessionId()).toBe(1);
+    expect(generateSessionId()).toBe(10_000_000);
+
+    randomSpy.mockRestore();
+  });
+
+  it('initializes one session id for the store session', () => {
+    const initialState = reducer(undefined, {} as types.SettingsActionTypes);
+    const nextInitialState = reducer(
+      undefined,
+      {} as types.SettingsActionTypes
+    );
+
+    expect(initialState.sessionId).toBeGreaterThanOrEqual(1);
+    expect(initialState.sessionId).toBeLessThanOrEqual(10_000_000);
+    expect(nextInitialState.sessionId).toBe(initialState.sessionId);
+  });
+
+  it('does not persist the session id', () => {
+    expect(settingsPersist.whitelist).not.toContain('sessionId');
   });
 
   it('selects theme fallback from config when no theme is stored', () => {

--- a/ios/MobileWeather.xcodeproj/project.pbxproj
+++ b/ios/MobileWeather.xcodeproj/project.pbxproj
@@ -387,6 +387,7 @@
 				92C4390534123651C377CBF9 /* [CP] Copy Pods Resources */,
 				A2E2E9A12CFDF6070096E794 /* Embed Foundation Extensions */,
 				A2D35D032F8CBD2200F66919 /* ShellScript */,
+				95F457F572F6E805DFF217FD /* [MapLibre React Native] Remove MapLibre.xcframework-ios.signature */,
 			);
 			buildRules = (
 			);
@@ -411,6 +412,7 @@
 				A2042C692CFF2EEE00C41A9E /* Frameworks */,
 				A2042C6A2CFF2EEE00C41A9E /* Resources */,
 				FA8FC7F78C2105829CA20A69 /* [CP] Copy Pods Resources */,
+				E3BEEF8F57B348730AB6043D /* [MapLibre React Native] Remove MapLibre.xcframework-ios.signature */,
 			);
 			buildRules = (
 			);
@@ -437,6 +439,7 @@
 				A2B3FF932CC7D1DA00EC1293 /* Frameworks */,
 				A2B3FF942CC7D1DA00EC1293 /* Resources */,
 				F155B79920AEB0D76A6275A4 /* [CP] Copy Pods Resources */,
+				0578B5B54E37683EA94F2DD0 /* [MapLibre React Native] Remove MapLibre.xcframework-ios.signature */,
 			);
 			buildRules = (
 			);
@@ -562,6 +565,25 @@
 			shellPath = /bin/sh;
 			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh\n";
 		};
+		0578B5B54E37683EA94F2DD0 /* [MapLibre React Native] Remove MapLibre.xcframework-ios.signature */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "[MapLibre React Native] Remove MapLibre.xcframework-ios.signature";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "rm -rf \"$CONFIGURATION_BUILD_DIR/MapLibre.xcframework-ios.signature\"";
+		};
 		7F9E47D269AB472DF14098D1 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -652,6 +674,25 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-MobileWeather/Pods-MobileWeather-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
+		95F457F572F6E805DFF217FD /* [MapLibre React Native] Remove MapLibre.xcframework-ios.signature */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "[MapLibre React Native] Remove MapLibre.xcframework-ios.signature";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "rm -rf \"$CONFIGURATION_BUILD_DIR/MapLibre.xcframework-ios.signature\"";
+		};
 		A2D35D032F8CBD2200F66919 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 8;
@@ -712,6 +753,25 @@
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
+		};
+		E3BEEF8F57B348730AB6043D /* [MapLibre React Native] Remove MapLibre.xcframework-ios.signature */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "[MapLibre React Native] Remove MapLibre.xcframework-ios.signature";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "rm -rf \"$CONFIGURATION_BUILD_DIR/MapLibre.xcframework-ios.signature\"";
 		};
 		EB9251EE28C9F1EBE2F707C9 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1345,7 +1405,7 @@
 			repositoryURL = "https://github.com/maplibre/maplibre-gl-native-distribution";
 			requirement = {
 				kind = exactVersion;
-				version = 6.25.0;
+				version = 6.26.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/MobileWeather.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/MobileWeather.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/maplibre/maplibre-gl-native-distribution",
       "state" : {
-        "revision" : "e0ee2c11a2859e22d3f0dd29705c18169bdafa7b",
-        "version" : "6.25.0"
+        "revision" : "be0696007ca8b350faa0e5968c0d6397d59db415",
+        "version" : "6.26.0"
       }
     }
   ],

--- a/ios/MobileWeather.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/MobileWeather.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/maplibre/maplibre-gl-native-distribution",
       "state" : {
-        "revision" : "e0ee2c11a2859e22d3f0dd29705c18169bdafa7b",
-        "version" : "6.25.0"
+        "revision" : "be0696007ca8b350faa0e5968c0d6397d59db415",
+        "version" : "6.26.0"
       }
     }
   ],

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -47,7 +47,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - ReactNativeDependencies
     - Yoga
-  - MapLibreReactNative (11.0.1):
+  - MapLibreReactNative (11.3.6):
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -2748,7 +2748,7 @@ SPEC CHECKSUMS:
   libdav1d: 23581a4d8ec811ff171ed5e2e05cd27bad64c39f
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   logicwind-react-native-matomo-tracker: 0fb8fc899ef1001e76c38556dfc182a9a32fb4c6
-  MapLibreReactNative: 9678b56ba428d81084c9357ca0bc24e10e273577
+  MapLibreReactNative: 9f1f16d5f5f522309ad1f2afc483a34cfc56fe6e
   MatomoTracker: dbf4093d2c36b78244ce481d7a10086fad825c7f
   RCTDeprecation: d69f6f20a20f669a0aa3115ab1109f28e98ae03e
   RCTRequired: 305a8212b9d90fa335b6a6a960e5212bbb434484

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@d11/react-native-fast-image": "8.11.0",
     "@logicwind/react-native-matomo-tracker": "0.3.12",
-    "@maplibre/maplibre-react-native": "11.0.1",
+    "@maplibre/maplibre-react-native": "11.3.6",
     "@react-native-async-storage/async-storage": "2.1.1",
     "@react-native-community/geolocation": "3.4.0",
     "@react-native-community/netinfo": "11.4.1",

--- a/src/components/map/maps/MlMapView.tsx
+++ b/src/components/map/maps/MlMapView.tsx
@@ -1,7 +1,15 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 import { View, StyleSheet, Text } from 'react-native';
-import { Camera, Map, ViewAnnotation, type MapRef, type CameraRef, InitialViewState } from '@maplibre/maplibre-react-native';
+import {
+  Camera,
+  Map,
+  TransformRequestManager,
+  ViewAnnotation,
+  type MapRef,
+  type CameraRef,
+  InitialViewState,
+} from '@maplibre/maplibre-react-native';
 import { useTheme, useIsFocused } from '@react-navigation/native';
 import moment from 'moment';
 import { getDistance } from 'geolib';
@@ -12,6 +20,7 @@ import MapControls from '@components/map/ui/MapControls';
 
 import { State } from '@store/types';
 import { selectCurrent, selectTimeZone } from '@store/location/selector';
+import { selectSessionId } from '@store/settings/selectors';
 import {
   selectActiveOverlay,
   selectDisplayLocation,
@@ -47,6 +56,8 @@ const ANIMATE_ZOOM = {
 const MIN_ZOOM_LEVEL = 4;
 const MAX_ZOOM_LEVEL = 10;
 const DEFAULT_ZOOM_LEVEL = 8;
+const SESSION_COOKIE_HEADER_ID = 'smartmet-session-cookie';
+const WMS_GET_MAP_REQUEST_PATTERN = '(?i)(?:[?&])request=GetMap(?:&|$)';
 
 const mapStateToProps = (state: State) => ({
   currentLocation: selectCurrent(state),
@@ -54,6 +65,7 @@ const mapStateToProps = (state: State) => ({
   overlay: selectOverlay(state),
   activeOverlay: selectActiveOverlay(state),
   timezone: selectTimeZone(state),
+  sessionId: selectSessionId(state),
 });
 
 const mapDispatchToProps = {
@@ -79,6 +91,7 @@ const MlMapView: React.FC<MapViewProps> = ({
   activeOverlay,
   updateOverlays,
   timezone,
+  sessionId,
   infoSheetRef,
   mapLayersSheetRef,
 }) => {
@@ -98,6 +111,17 @@ const MlMapView: React.FC<MapViewProps> = ({
 
   const location = currentLocation ?? Config.get('location').default;
   const { baseMap } = Config.get('map');
+
+  useEffect(() => {
+    TransformRequestManager.addHeader({
+      id: SESSION_COOKIE_HEADER_ID,
+      match: WMS_GET_MAP_REQUEST_PATTERN,
+      name: 'Cookie',
+      value: `smartmet-session-id=${sessionId}`,
+    });
+
+    return () => TransformRequestManager.removeHeader(SESSION_COOKIE_HEADER_ID);
+  }, [sessionId]);
 
   const initialRegion = useMemo(() => ({
     latitude: location.lat ?? INITIAL_REGION.latitude,

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -35,7 +35,7 @@ import UnitSettings from '@components/settings/UnitSettings';
 import LanguageSettings from '@components/settings/LanguageSettings';
 import ThemeSettings from '@components/settings/ThemeSettings';
 import TimeSettings from '@components/settings/TimeSettings';
-//import MapSettings from '@components/settings/MapSettings';
+import MapSettings from '@components/settings/MapSettings';
 
 const LOCATION_ALWAYS = 'location_always';
 const LOCATION_WHEN_IN_USE = 'location_when_in_use';
@@ -68,13 +68,13 @@ const SettingsScreen: React.FC<Props> = ({
   theme,
   geoids,
   units,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
   mapLibrary,
   updateUnits,
   updateClockType,
   updateTheme,
   updateLocationsLocales,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
   updateMapLibrary
 }) => {
   const [locationPermission, setLocationPermission] = useState<
@@ -211,12 +211,10 @@ const SettingsScreen: React.FC<Props> = ({
           <UnitSettings units={units} onChangeUnits={onChangeUnits} />
         )}
 
-        { /*
         <MapSettings
           mapLibrary={mapLibrary}
           updateMapLibrary={updateMapLibrary}
         />
-        */}
       </ScrollView>
     </View>
   );

--- a/src/store/settings/reducer.ts
+++ b/src/store/settings/reducer.ts
@@ -9,11 +9,17 @@ import {
   UPDATE_MAP_LIBRARY,
 } from './types';
 
+const SESSION_ID_MAX = 10_000_000;
+
+export const generateSessionId = () =>
+  Math.floor(Math.random() * SESSION_ID_MAX) + 1;
+
 const INITIAL_STATE: SettingsState = {
   units: getDefaultUnits(),
   theme: undefined,
   clockType: undefined,
   mapLibrary: 'react-native-maps',
+  sessionId: generateSessionId(),
 };
 
 export default (

--- a/src/store/settings/selectors.ts
+++ b/src/store/settings/selectors.ts
@@ -39,3 +39,8 @@ export const selectMapLibrary = createSelector(
   selectSettingsDomain,
   (settings) => settings.mapLibrary
 );
+
+export const selectSessionId = createSelector(
+  selectSettingsDomain,
+  (settings) => settings.sessionId
+);

--- a/src/store/settings/types.ts
+++ b/src/store/settings/types.ts
@@ -58,4 +58,5 @@ export interface SettingsState {
   units: UnitMap | undefined;
   theme?: Theme;
   mapLibrary: MapLibrary;
+  sessionId: number; // smartmet-session-id for wms-layer requests
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1850,29 +1850,28 @@
   resolved "https://registry.yarnpkg.com/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz#d32deb66c7177e9e9dfc3bbd697083e2e657ff01"
   integrity sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==
 
-"@maplibre/maplibre-gl-style-spec@24.8.1":
-  version "24.8.1"
-  resolved "https://registry.yarnpkg.com/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.8.1.tgz#8d4d48591750529ce586f9ee5f836ed97870bce5"
-  integrity sha512-zxa92qF96ZNojLxeAjnaRpjVCy+swoUNJvDhtpC90k7u5F0TMr4GmvNqMKvYrMoPB8d7gRSXbMG1hBbmgESIsw==
+"@maplibre/maplibre-gl-style-spec@24.8.5":
+  version "24.8.5"
+  resolved "https://registry.yarnpkg.com/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.8.5.tgz#ddf33510e3a1b491d011c2f4a18253035e44ba95"
+  integrity sha512-EzEJmMt6thioRH7GI9LWS7ahXTcAhAPGWCe6oTP2Ps4YnsXOOAfeqx854lZaiDnwURfHmcCKV1mr6oo0i23x6w==
   dependencies:
     "@mapbox/jsonlint-lines-primitives" "~2.0.2"
     "@mapbox/unitbezier" "^0.0.1"
     json-stringify-pretty-compact "^4.0.0"
     minimist "^1.2.8"
     quickselect "^3.0.0"
-    rw "^1.3.3"
     tinyqueue "^3.0.0"
 
-"@maplibre/maplibre-react-native@11.0.1":
-  version "11.0.1"
-  resolved "https://registry.yarnpkg.com/@maplibre/maplibre-react-native/-/maplibre-react-native-11.0.1.tgz#a3fc3f5c1fa122d569f105ec418f6a108d9402fe"
-  integrity sha512-d6jbfGT7YT5lX29LkFhxYq8Gbsf8c51zIwMqBz+aiVNlkCGRusE/jZInmXdCstPY2TcHsAcl07+fiYThl80wCQ==
+"@maplibre/maplibre-react-native@11.3.6":
+  version "11.3.6"
+  resolved "https://registry.yarnpkg.com/@maplibre/maplibre-react-native/-/maplibre-react-native-11.3.6.tgz#2ef310f44e9668371d2e499e11088ec879f985b2"
+  integrity sha512-XLl8mR7ogThpJKHnxG7PGK2TB9CwJJa8xOM2emsTgVGBzQZ3cc5mfW+mSTwP3PbBDfJe/WSFOIfOU2oHMD5mZQ==
   dependencies:
-    "@maplibre/maplibre-gl-style-spec" "24.8.1"
-    "@turf/distance" "^7.1.0"
-    "@turf/helpers" "^7.1.0"
-    "@turf/length" "^7.1.0"
-    "@turf/nearest-point-on-line" "^7.1.0"
+    "@maplibre/maplibre-gl-style-spec" "24.8.5"
+    "@turf/distance" "^7.3.5"
+    "@turf/helpers" "^7.3.5"
+    "@turf/length" "^7.3.5"
+    "@turf/nearest-point-on-line" "^7.3.5"
 
 "@motionone/animation@^10.12.0":
   version "10.18.0"
@@ -2534,61 +2533,62 @@
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
 
-"@turf/distance@7.3.1", "@turf/distance@^7.1.0":
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/@turf/distance/-/distance-7.3.1.tgz#165d868c31eed69f6e9dc6e4ea292b9ae498546c"
-  integrity sha512-DK//doTGgYYjBkcWUywAe7wbZYcdP97hdEJ6rXYVYRoULwGGR3lhY96GNjozg6gaW9q2eSNYnZLpcL5iFVHqgw==
+"@turf/distance@7.4.0", "@turf/distance@^7.3.5":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@turf/distance/-/distance-7.4.0.tgz#7ddbc863f6e510749b60f02780f3c96fb8d2db06"
+  integrity sha512-ODkopQDG1m/U6Mx7OMmShncaCvneomwX3lZY1CDA7x40bhDdTTRYP/n/6LicZVyIO4/oK+aXkov4NOtWYthA2g==
   dependencies:
-    "@turf/helpers" "7.3.1"
-    "@turf/invariant" "7.3.1"
+    "@turf/helpers" "7.4.0"
+    "@turf/invariant" "7.4.0"
     "@types/geojson" "^7946.0.10"
     tslib "^2.8.1"
 
-"@turf/helpers@7.3.1", "@turf/helpers@^7.1.0":
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-7.3.1.tgz#2f0e666ecdefbf75d0df1b94ea1f5ccc6e4abc5b"
-  integrity sha512-zkL34JVhi5XhsuMEO0MUTIIFEJ8yiW1InMu4hu/oRqamlY4mMoZql0viEmH6Dafh/p+zOl8OYvMJ3Vm3rFshgg==
+"@turf/helpers@7.4.0", "@turf/helpers@^7.3.5":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@turf/helpers/-/helpers-7.4.0.tgz#5589f04812ac95f8985e9396db01d9e70f4a35d5"
+  integrity sha512-7PAwLZqOdRzTI5g9bHvUwlloAXPDH/mlajtryk0tw4ZwGMtmXsAyF4QundsAMfy4u48Fyd3AUqMXY0SMxqJGWg==
   dependencies:
     "@types/geojson" "^7946.0.10"
     tslib "^2.8.1"
 
-"@turf/invariant@7.3.1":
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-7.3.1.tgz#9b0bb8f74af870f0b10a2e9285e62f4983f99ac2"
-  integrity sha512-IdZJfDjIDCLH+Gu2yLFoSM7H23sdetIo5t4ET1/25X8gi3GE2XSqbZwaGjuZgNh02nisBewLqNiJs2bo+hrqZA==
+"@turf/invariant@7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@turf/invariant/-/invariant-7.4.0.tgz#b96eb3a1965cca126fcf15571058d126cc7a32e2"
+  integrity sha512-OAsc3qdNx+tRqzWmMNFMnVlWWACIqnYqIejZKvb2oKkKPYJJrURPXZ6OdrGD58ljJMolLoqwIZGSx3VndaEjxg==
   dependencies:
-    "@turf/helpers" "7.3.1"
+    "@turf/helpers" "7.4.0"
     "@types/geojson" "^7946.0.10"
     tslib "^2.8.1"
 
-"@turf/length@^7.1.0":
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/@turf/length/-/length-7.3.1.tgz#e766708527649ea5e01f6ccfc6101b26cfb70bb8"
-  integrity sha512-QOr4qS3yi6qWIfQ/KLcy4rDLdemGCYpqz2YDh29R46seE+arSvlBI0KXvI36rPzgEMcUbQuVQyO65sOSqPaEjQ==
+"@turf/length@^7.3.5":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@turf/length/-/length-7.4.0.tgz#9636b32ea3fa70b02ca51957550adff78749d96a"
+  integrity sha512-vQsJLuL7uy8m6HAMuJJKoiOHYY1de1Hd6mY/fM90qfu2RyIrkoF8J4bRUb72XZNCVnvob/eHpUMdhZeoUhSyfQ==
   dependencies:
-    "@turf/distance" "7.3.1"
-    "@turf/helpers" "7.3.1"
-    "@turf/meta" "7.3.1"
+    "@turf/distance" "7.4.0"
+    "@turf/helpers" "7.4.0"
+    "@turf/meta" "7.4.0"
     "@types/geojson" "^7946.0.10"
     tslib "^2.8.1"
 
-"@turf/meta@7.3.1":
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-7.3.1.tgz#af2076f6388ea87585190c99b8530cbb05e38944"
-  integrity sha512-NWsfOE5RVtWpLQNkfOF/RrYvLRPwwruxhZUV0UFIzHqfiRJ50aO9Y6uLY4bwCUe2TumLJQSR4yaoA72Rmr2mnQ==
+"@turf/meta@7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@turf/meta/-/meta-7.4.0.tgz#99c3b3af4c2e5a7ef0b4f99c9f42120e82a91e62"
+  integrity sha512-3cLUvlEyDuSnMSzrjhaLAEiYR8xhbfWyTVQlrlEw40xL81d4KF4PqUWbjTXKpXZStdYbet2GCurl79KMypNw6g==
   dependencies:
-    "@turf/helpers" "7.3.1"
+    "@turf/helpers" "7.4.0"
     "@types/geojson" "^7946.0.10"
+    tslib "^2.8.1"
 
-"@turf/nearest-point-on-line@^7.1.0":
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/@turf/nearest-point-on-line/-/nearest-point-on-line-7.3.1.tgz#f8f45aed81ee6fc79529815a5aa97f49a06e7d18"
-  integrity sha512-FialyHfXXZWLayKQcUtdOtKv3ulOQ9FSI45kSmkDl8b96+VFWHX983Pc94tTrSTSg89+XX7MDr6gRl0yowmF4Q==
+"@turf/nearest-point-on-line@^7.3.5":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@turf/nearest-point-on-line/-/nearest-point-on-line-7.4.0.tgz#b4d46251eb6335ffc794eae315dd22932362d951"
+  integrity sha512-eKTKf/qODIsPankYMZrNfI3LjLaVtQvYV/1hcj9kH/Zr3GfLUszevjhTRDZtMgTFrv8+awW3+MyhmN+PJGuLdQ==
   dependencies:
-    "@turf/distance" "7.3.1"
-    "@turf/helpers" "7.3.1"
-    "@turf/invariant" "7.3.1"
-    "@turf/meta" "7.3.1"
+    "@turf/distance" "7.4.0"
+    "@turf/helpers" "7.4.0"
+    "@turf/invariant" "7.4.0"
+    "@turf/meta" "7.4.0"
     "@types/geojson" "^7946.0.10"
     tslib "^2.8.1"
 
@@ -8846,11 +8846,6 @@ run-parallel@^1.1.9:
   integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
   dependencies:
     queue-microtask "^1.2.2"
-
-rw@^1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
-  integrity sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==
 
 safe-array-concat@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
`smartmet-session-id` cookie is sent when MapLibre React Native is in use, react-native-maps doesn't support sending custom headers.

Also updated MapLibre React Native to latest version and enabled map library selection in settings again.

Closes #1370 