### PR TITLE
issue-1440: Improved wms- and timeseries- layer updates

### DIFF
--- a/__tests__/components/MlMapView.test.tsx
+++ b/__tests__/components/MlMapView.test.tsx
@@ -196,6 +196,10 @@ describe('MlMapView', () => {
     });
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('dispatches overlay update and renders WMS overlay after style is ready', async () => {
     const store = createStore({
       mock: {
@@ -241,6 +245,53 @@ describe('MlMapView', () => {
         })
       );
     });
+  });
+
+  it('updates overlays when the update interval has elapsed', () => {
+    jest
+      .spyOn(Date, 'now')
+      .mockReturnValueOnce(1_000_000)
+      .mockReturnValueOnce(1_000_000)
+      .mockReturnValue(1_060_000);
+    mockConfigGet.mockImplementation((key: string) => {
+      if (key === 'map') {
+        return {
+          updateInterval: 1,
+          baseMap: {
+            url: 'https://maps.example/',
+            darkStyle: 'dark',
+            lightStyle: 'light',
+          },
+        };
+      }
+      if (key === 'location') {
+        return { default: { lat: 60.1699, lon: 24.9384 } };
+      }
+      return {};
+    });
+
+    const store = createStore({
+      mock: {
+        currentLocation: undefined,
+        displayLocation: false,
+        overlay: { type: 'WMS', step: 60 },
+        activeOverlay: 3,
+        timezone: 'Europe/Helsinki',
+        sessionId: 1234567,
+      },
+    });
+
+    render(
+      <Provider store={store as any}>
+        <MlMapView
+          infoSheetRef={{ current: null }}
+          mapLayersSheetRef={{ current: null }}
+        />
+      </Provider>
+    );
+
+    expect(mockUpdateOverlays).toHaveBeenCalledTimes(2);
+    expect(mockUpdateOverlays).toHaveBeenLastCalledWith(3, 'maplibre');
   });
 
   it('passes bounds to timeseries overlay and wires map controls actions', async () => {

--- a/__tests__/components/RnMapView.test.tsx
+++ b/__tests__/components/RnMapView.test.tsx
@@ -170,6 +170,10 @@ describe('RnMapView', () => {
     });
   });
 
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('dispatches overlay update and renders WMS overlay with marker', () => {
     const store = createStore({
       mock: {
@@ -209,6 +213,46 @@ describe('RnMapView', () => {
       })
     );
     expect(mockMapRefApi.animateToRegion).toHaveBeenCalled();
+  });
+
+  it('updates overlays when the update interval has elapsed', () => {
+    jest
+      .spyOn(Date, 'now')
+      .mockReturnValueOnce(1_000_000)
+      .mockReturnValueOnce(1_000_000)
+      .mockReturnValue(1_060_000);
+    mockConfigGet.mockImplementation((key: string) => {
+      if (key === 'map') return { updateInterval: 1 };
+      if (key === 'location') {
+        return { default: { lat: 60.1699, lon: 24.9384 } };
+      }
+      return {};
+    });
+
+    const store = createStore({
+      mock: {
+        currentLocation: undefined,
+        displayLocation: false,
+        overlay: { type: 'WMS', step: 60 },
+        activeOverlay: 3,
+        timezone: 'Europe/Helsinki',
+      },
+    });
+
+    render(
+      <Provider store={store as any}>
+        <RnMapView
+          infoSheetRef={{ current: null }}
+          mapLayersSheetRef={{ current: null }}
+        />
+      </Provider>
+    );
+
+    expect(mockUpdateOverlays).toHaveBeenCalledTimes(2);
+    expect(mockUpdateOverlays).toHaveBeenLastCalledWith(
+      3,
+      'react-native-maps'
+    );
   });
 
   it('uses native camera zoom range on iOS', () => {

--- a/__tests__/config/provider.test.tsx
+++ b/__tests__/config/provider.test.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { Text } from 'react-native';
-import { render, waitFor } from '@testing-library/react-native';
+import { act, render, waitFor } from '@testing-library/react-native';
 import { MMKV } from 'react-native-mmkv';
 
 import { Config, ConfigProvider } from '@config';
 import axiosClient from '@utils/axiosClient';
+import { useReloader } from '@utils/reloader';
 import defaultConfig from './testConfig';
 
 jest.mock('@utils/axiosClient', () => jest.fn());
@@ -19,12 +20,20 @@ jest.mock('react-native-launch-arguments', () => {
 });
 
 const TestComponent = () => <Text>{Config.get('weather').apiUrl}</Text>;
+const ReloaderTestComponent = () => {
+  const { shouldReload } = useReloader();
+  return <Text testID="should-reload">{shouldReload}</Text>;
+};
 
 describe('ConfigProvider children renders', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     (Config as any).hasBeenSet = false;
     new MMKV().clearAll();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
   afterAll(() => {
@@ -46,6 +55,33 @@ describe('ConfigProvider children renders', () => {
       props: {},
       children: ['weatherApiUrl'],
     });
+    container.unmount();
+  });
+
+  it('publishes a reload heartbeat every ten seconds', () => {
+    jest.useFakeTimers();
+    const noReloadConfig = JSON.parse(JSON.stringify(defaultConfig));
+    noReloadConfig.dynamicConfig.enabled = false;
+    const container = render(
+      <ConfigProvider defaultConfig={noReloadConfig}>
+        <ReloaderTestComponent />
+      </ConfigProvider>
+    );
+
+    expect(container.getByTestId('should-reload').props.children).toBe(0);
+
+    act(() => {
+      jest.advanceTimersByTime(9_999);
+    });
+    expect(container.getByTestId('should-reload').props.children).toBe(0);
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(container.getByTestId('should-reload').props.children).toBeGreaterThan(
+      0
+    );
+
     container.unmount();
   });
 

--- a/__tests__/store/map.test.ts
+++ b/__tests__/store/map.test.ts
@@ -96,7 +96,148 @@ describe('map reducer', () => {
     });
   });
 
+  it('preserves state when refreshed WMS overlay data is unchanged', () => {
+    const observation = dummyOverlay.observation as types.Layer;
+    const forecast = dummyOverlay.forecast as types.Layer;
+    const currentOverlay: types.MapOverlay = {
+      ...dummyOverlay,
+      observation: {
+        ...observation,
+        styles: { dark: 'dark', light: 'light' },
+      },
+    };
+    const currentState = {
+      ...initial,
+      overlays: new Map([[1, currentOverlay]]),
+      sliderTime: 123,
+    };
+    const refreshedObservation: types.Layer = {
+      ...observation,
+      styles: { dark: 'dark', light: 'light' },
+    };
+    const refreshedOverlay: types.MapOverlay = {
+      ...currentOverlay,
+      observation: refreshedObservation,
+      forecast: { ...forecast },
+    };
+    const refreshedOverlays = new Map([[1, refreshedOverlay]]);
+
+    const nextState = reducer(currentState, {
+      type: types.UPDATE_OVERLAYS_SUCCESS,
+      overlays: refreshedOverlays,
+    });
+
+    expect(nextState).toBe(currentState);
+    expect(nextState.sliderTime).toBe(123);
+  });
+
+  it('updates state when refreshed WMS overlay data has changed', () => {
+    const forecast = dummyOverlay.forecast as types.Layer;
+    const currentState = {
+      ...initial,
+      overlays: new Map([[1, dummyOverlay]]),
+      sliderTime: 123,
+    };
+    const changedOverlays = new Map<number, types.MapOverlay>([
+      [
+        1,
+        {
+          ...dummyOverlay,
+          forecast: {
+            ...forecast,
+            end: '2021-01-01T02:00:00Z',
+          },
+        },
+      ],
+    ]);
+
+    const nextState = reducer(currentState, {
+      type: types.UPDATE_OVERLAYS_SUCCESS,
+      overlays: changedOverlays,
+    });
+
+    expect(nextState).not.toBe(currentState);
+    expect(nextState.overlays).toBe(changedOverlays);
+    expect(nextState.sliderTime).toBe(0);
+  });
+
+  it('preserves state when refreshed Timeseries ETag is unchanged', () => {
+    const currentOverlay: types.MapOverlay = {
+      type: 'Timeseries',
+      etag: '"timeseries-v1"',
+      step: 60,
+      data: [],
+    };
+    const currentState = {
+      ...initial,
+      overlays: new Map([[8, currentOverlay]]),
+      sliderTime: 123,
+    };
+    const refreshedOverlays = new Map<number, types.MapOverlay>([
+      [8, { ...currentOverlay, data: [] }],
+    ]);
+
+    const nextState = reducer(currentState, {
+      type: types.UPDATE_OVERLAYS_SUCCESS,
+      overlays: refreshedOverlays,
+    });
+
+    expect(nextState).toBe(currentState);
+    expect(nextState.sliderTime).toBe(123);
+  });
+
+  it('updates Timeseries state when ETag changes, is missing or metadata changes', () => {
+    const currentOverlay: types.MapOverlay = {
+      type: 'Timeseries',
+      etag: '"timeseries-v1"',
+      step: 60,
+      data: [],
+    };
+    const currentState = {
+      ...initial,
+      overlays: new Map([[8, currentOverlay]]),
+      sliderTime: 123,
+    };
+    const changedOverlays = new Map<number, types.MapOverlay>([
+      [8, { ...currentOverlay, etag: '"timeseries-v2"', data: [] }],
+    ]);
+    const missingEtagOverlays = new Map<number, types.MapOverlay>([
+      [8, { ...currentOverlay, etag: undefined, data: [] }],
+    ]);
+    const changedMetadataOverlays = new Map<number, types.MapOverlay>([
+      [
+        8,
+        {
+          ...currentOverlay,
+          forecast: { end: '2026-08-17T12:00:00Z' },
+          data: [],
+        },
+      ],
+    ]);
+
+    expect(
+      reducer(currentState, {
+        type: types.UPDATE_OVERLAYS_SUCCESS,
+        overlays: changedOverlays,
+      }).overlays
+    ).toBe(changedOverlays);
+    expect(
+      reducer(currentState, {
+        type: types.UPDATE_OVERLAYS_SUCCESS,
+        overlays: missingEtagOverlays,
+      }).overlays
+    ).toBe(missingEtagOverlays);
+    expect(
+      reducer(currentState, {
+        type: types.UPDATE_OVERLAYS_SUCCESS,
+        overlays: changedMetadataOverlays,
+      }).overlays
+    ).toBe(changedMetadataOverlays);
+  });
+
   it('should handle UPDATE_OVERLAYS and UPDATE_OVERLAYS_ERROR', () => {
+    expect(reducer(initial, { type: types.UPDATE_OVERLAYS })).toBe(initial);
+
     expect(
       reducer({ ...initial, overlaysError: 'failed' }, {
         type: types.UPDATE_OVERLAYS,

--- a/__tests__/utils/map.test.ts
+++ b/__tests__/utils/map.test.ts
@@ -134,7 +134,10 @@ describe('map helper functions', () => {
       fs.readFileSync(path.join(__dirname, '../data/timeseries.json'), 'utf8')
     );
 
-    (axiosClient as jest.Mock).mockResolvedValueOnce({ data: timeseriesData });
+    (axiosClient as jest.Mock).mockResolvedValueOnce({
+      data: timeseriesData,
+      headers: { etag: '"timeseries-v1"' },
+    });
 
     const sources = {
       smartmet: 'https://example.test',
@@ -187,6 +190,7 @@ describe('map helper functions', () => {
 
     expect(parsedOverlay?.type).toBe('Timeseries');
     expect(parsedOverlay?.data).toBe(timeseriesData);
+    expect(parsedOverlay?.etag).toBe('"timeseries-v1"');
 
     const timeseries = parsedOverlay?.data as any;
     const helsinki =

--- a/src/components/map/maps/MlMapView.tsx
+++ b/src/components/map/maps/MlMapView.tsx
@@ -149,7 +149,7 @@ const MlMapView: React.FC<MapViewProps> = ({
   useEffect(() => {
     const now = Date.now();
     const mapUpdateTime = mapUpdated + (updateInterval ?? 5) * 60 * 1000;
-    if (isFocused && (now > mapUpdateTime || shouldReload > mapUpdateTime)) {
+    if (isFocused && (now >= mapUpdateTime || shouldReload >= mapUpdateTime)) {
       updateOverlays(activeOverlay, 'maplibre');
       setMapUpdated(now);
     }

--- a/src/components/map/maps/RnMapView.tsx
+++ b/src/components/map/maps/RnMapView.tsx
@@ -120,7 +120,7 @@ const RnMapView: React.FC<MapViewProps> = ({
   useEffect(() => {
     const now = Date.now();
     const mapUpdateTime = mapUpdated + (updateInterval ?? 5) * 60 * 1000;
-    if (isFocused && (now > mapUpdateTime || shouldReload > mapUpdateTime)) {
+    if (isFocused && (now >= mapUpdateTime || shouldReload >= mapUpdateTime)) {
       updateOverlays(activeOverlay, 'react-native-maps');
       setMapUpdated(now);
     }

--- a/src/config/ConfigProvider.tsx
+++ b/src/config/ConfigProvider.tsx
@@ -13,12 +13,15 @@ type ConfigProviderProps = {
   timeout?: number;
 };
 
+// This is only interval to check if update is needed,
+// Individual update intervals defined in the config are respected.
+const RELOAD_INTERVAL_MS = 10_000;
+
 const ConfigProvider: React.FC<ConfigProviderProps> = ({
   children,
   defaultConfig,
   timeout,
 }) => {
-  const reloadInterval = 60000;
   const [restored, setRestored] = useState<boolean>(false);
   const [updated, setUpdated] = useState<number>(0);
   const [shouldReload, setShouldReload] = useState<number>(0);
@@ -67,12 +70,10 @@ const ConfigProvider: React.FC<ConfigProviderProps> = ({
 
         reloadIntervalRef.current = setInterval(
           () => setShouldReload(Date.now()),
-          reloadInterval
+          RELOAD_INTERVAL_MS
         );
-      } else {
-        if (reloadIntervalRef.current) {
-          clearInterval(reloadIntervalRef.current);
-        }
+      } else if (reloadIntervalRef.current) {
+        clearInterval(reloadIntervalRef.current);
       }
     };
     const appStateSubscriber = AppState.addEventListener(
@@ -94,7 +95,7 @@ const ConfigProvider: React.FC<ConfigProviderProps> = ({
   useEffect(() => {
     reloadIntervalRef.current = setInterval(
       () => setShouldReload(Date.now()),
-      reloadInterval
+      RELOAD_INTERVAL_MS
     );
 
     // Cleanup on unmount

--- a/src/store/map/reducer.ts
+++ b/src/store/map/reducer.ts
@@ -6,13 +6,86 @@ import {
   UPDATE_OVERLAYS,
   UPDATE_OVERLAYS_SUCCESS,
   UPDATE_OVERLAYS_ERROR,
+  Layer,
   MapActionTypes,
+  MapOverlay,
   MapState,
+  TimeseriesLayer,
   UPDATE_ACTIVE_OVERLAY,
   UPDATE_REGION,
   UPDATE_SELECTED_CALLOUT,
   UPDATE_ANIMATION_SPEED,
 } from './types';
+
+const areLayerStylesEqual = (first: Layer['styles'], second: Layer['styles']) =>
+  typeof first === 'string' || typeof second === 'string'
+    ? first === second
+    : first.dark === second.dark && first.light === second.light;
+
+const areLayersEqual = (first?: Layer, second?: Layer) => {
+  if (first === second) return true;
+  if (!first || !second) return false;
+
+  return (
+    first.url === second.url &&
+    first.start === second.start &&
+    first.end === second.end &&
+    areLayerStylesEqual(first.styles, second.styles)
+  );
+};
+
+const areTimeseriesLayersEqual = (
+  first?: TimeseriesLayer,
+  second?: TimeseriesLayer
+) => {
+  if (first === second) return true;
+  if (!first || !second) return false;
+
+  return first.start === second.start && first.end === second.end;
+};
+
+const areOverlayMapsEqual = (
+  current: Map<number, MapOverlay> | undefined,
+  next: Map<number, MapOverlay>
+) => {
+  if (!current || current.size !== next.size) return false;
+
+  return [...next.entries()].every(([id, nextOverlay]) => {
+    const currentOverlay = current.get(id);
+    if (!currentOverlay || currentOverlay.type !== nextOverlay.type) {
+      return false;
+    }
+
+    if (currentOverlay.type === 'Timeseries') {
+      return (
+        Boolean(currentOverlay.etag) &&
+        currentOverlay.etag === nextOverlay.etag &&
+        currentOverlay.step === nextOverlay.step &&
+        areTimeseriesLayersEqual(
+          currentOverlay.observation as TimeseriesLayer | undefined,
+          nextOverlay.observation as TimeseriesLayer | undefined
+        ) &&
+        areTimeseriesLayersEqual(
+          currentOverlay.forecast as TimeseriesLayer | undefined,
+          nextOverlay.forecast as TimeseriesLayer | undefined
+        )
+      );
+    }
+
+    return (
+      currentOverlay.step === nextOverlay.step &&
+      currentOverlay.tileSize === nextOverlay.tileSize &&
+      areLayersEqual(
+        currentOverlay.observation as Layer | undefined,
+        nextOverlay.observation as Layer | undefined
+      ) &&
+      areLayersEqual(
+        currentOverlay.forecast as Layer | undefined,
+        nextOverlay.forecast as Layer | undefined
+      )
+    );
+  });
+};
 
 const INITIAL_STATE: MapState = {
   mapLayers: {
@@ -54,6 +127,8 @@ export default (state = INITIAL_STATE, action: MapActionTypes): MapState => {
     }
 
     case UPDATE_OVERLAYS: {
+      if (state.overlaysError === false) return state;
+
       return {
         ...state,
         overlaysError: false,
@@ -61,6 +136,8 @@ export default (state = INITIAL_STATE, action: MapActionTypes): MapState => {
     }
 
     case UPDATE_OVERLAYS_SUCCESS: {
+      if (areOverlayMapsEqual(state.overlays, action.overlays)) return state;
+
       return {
         ...state,
         overlays: action.overlays,

--- a/src/store/map/types.ts
+++ b/src/store/map/types.ts
@@ -104,6 +104,7 @@ export type TimeseriesData = {
 
 export interface MapOverlay {
   type: 'WMS' | 'Timeseries';
+  etag?: string;
   observation?: Layer | TimeseriesLayer;
   forecast?: Layer | TimeseriesLayer;
   data?: TimeseriesData[];

--- a/src/utils/map.ts
+++ b/src/utils/map.ts
@@ -164,10 +164,16 @@ export const getTimeseriesData = async (
   };
 
   const url = `${sources[layer.source]}/timeseries`;
-  const { data } = await axiosClient({ url, params }, undefined, 'Timeseries');
+  const { data, headers } = await axiosClient(
+    { url, params },
+    undefined,
+    'Timeseries'
+  );
+  const responseEtag = headers?.get?.('etag') ?? headers?.etag;
 
   Object.assign(toReturn, {
     data,
+    etag: typeof responseEtag === 'string' ? responseEtag : undefined,
     order: [
       ...new Set(
         Object.keys(data)


### PR DESCRIPTION
Improved map layer update logic so that shorter update intervals like 1 minute are possible without causing unnecessary UI updates. State is not updated if there no changes in data. Also noticed that update interval in `ConfigProvider` was too long and it caused that minimum update interval was usually 2 minutes even 1 minute interval was defined in configuration.

Closes #1440 